### PR TITLE
feat: player profile screen and games history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ __marimo__/
 
 # Frontend
 frontend/node_modules/
+frontend/dist/
+frontend/.vite/
+frontend/.vite/deps/_metadata.json

--- a/frontend/.vite/deps/_metadata.json
+++ b/frontend/.vite/deps/_metadata.json
@@ -1,8 +1,0 @@
-{
-  "hash": "afb98ad9",
-  "configHash": "613a5f88",
-  "lockfileHash": "fbe75aa3",
-  "browserHash": "7c99781f",
-  "optimized": {},
-  "chunks": {}
-}

--- a/frontend/.vite/deps/package.json
+++ b/frontend/.vite/deps/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,11 @@ import ProtectedRoute from '@/components/ProtectedRoute/ProtectedRoute'
 import Login from '@/pages/Login/Login'
 import Home from '@/pages/Home/Home'
 import Players from '@/pages/Players/Players'
+import PlayerProfile from '@/pages/PlayerProfile/PlayerProfile'
 import GameForm from '@/pages/GameForm/GameForm'
 import GameRecords from '@/pages/GameRecords/GameRecords'
+import GamesList from '@/pages/GamesList/GamesList'
+import GameDetail from '@/pages/GameDetail/GameDetail'
 import Records from '@/pages/Records/Records'
 
 export default function App() {
@@ -32,10 +35,34 @@ export default function App() {
             }
           />
           <Route
+            path="/players/:playerId/profile"
+            element={
+              <ProtectedRoute>
+                <PlayerProfile />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/games"
+            element={
+              <ProtectedRoute>
+                <GamesList />
+              </ProtectedRoute>
+            }
+          />
+          <Route
             path="/games/new"
             element={
               <ProtectedRoute>
                 <GameForm />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/games/:gameId"
+            element={
+              <ProtectedRoute>
+                <GameDetail />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -1,8 +1,16 @@
 import { api } from './client'
-import type { GameDTO, GameCreatedResponseDTO, GameRecordsDTO } from '@/types'
+import type { GameDTO, GameCreatedResponseDTO, GameRecordsDTO, GameResultDTO } from '@/types'
 
 export function createGame(data: GameDTO): Promise<GameCreatedResponseDTO> {
   return api.post<GameCreatedResponseDTO>('/games/', data)
+}
+
+export function listGames(): Promise<GameDTO[]> {
+  return api.get<GameDTO[]>('/games/')
+}
+
+export function getGameResults(gameId: string): Promise<GameResultDTO> {
+  return api.get<GameResultDTO>(`/games/${gameId}/results`)
 }
 
 export function getGameRecords(gameId: string): Promise<GameRecordsDTO> {

--- a/frontend/src/api/players.ts
+++ b/frontend/src/api/players.ts
@@ -4,11 +4,16 @@ import type {
   PlayerCreateDTO,
   PlayerUpdateDTO,
   PlayerCreatedResponseDTO,
+  PlayerProfileDTO,
 } from '@/types'
 
 export function getPlayers(active?: boolean): Promise<PlayerResponseDTO[]> {
   const query = active == true ? `?active=${active}` : ''
   return api.get<PlayerResponseDTO[]>(`/players/${query}`)
+}
+
+export function getPlayerProfile(playerId: string): Promise<PlayerProfileDTO> {
+  return api.get<PlayerProfileDTO>(`/players/${playerId}/profile`)
 }
 
 export function createPlayer(data: PlayerCreateDTO): Promise<PlayerCreatedResponseDTO> {

--- a/frontend/src/components/RecordsSection/RecordsSection.module.css
+++ b/frontend/src/components/RecordsSection/RecordsSection.module.css
@@ -1,0 +1,48 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xl);
+}
+
+.recordItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  gap: var(--spacing-sm);
+}
+
+.recordItem.newRecord {
+  border-color: var(--color-accent);
+  background-color: rgba(230, 126, 34, 0.08);
+}
+
+.recordType {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.recordValue {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text);
+}
+
+.newBadge {
+  font-size: var(--font-size-sm);
+  background-color: var(--color-accent);
+  color: var(--color-background);
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--border-radius-sm);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+}
+
+.placeholder {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: var(--spacing-xl);
+}

--- a/frontend/src/components/RecordsSection/RecordsSection.tsx
+++ b/frontend/src/components/RecordsSection/RecordsSection.tsx
@@ -1,0 +1,46 @@
+import Spinner from '@/components/Spinner/Spinner'
+import type { GameRecordItemDTO } from '@/types'
+import styles from './RecordsSection.module.css'
+
+interface Props {
+  records: GameRecordItemDTO[] | null
+  loading: boolean
+  notAvailable: boolean
+}
+
+export default function RecordsSection({ records, loading, notAvailable }: Props) {
+  if (loading) return <Spinner />
+
+  if (notAvailable) {
+    return (
+      <div className={styles.placeholder}>
+        <p>Los records de esta partida estarán disponibles próximamente.</p>
+      </div>
+    )
+  }
+
+  if (!records || records.length === 0) {
+    return (
+      <div className={styles.placeholder}>
+        <p>No se superaron records en esta partida.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.list}>
+      {records.map((record, i) => (
+        <div
+          key={i}
+          className={[styles.recordItem, record.is_new_record ? styles.newRecord : ''].join(' ')}
+        >
+          <div>
+            <p className={styles.recordType}>{record.type}</p>
+            <p className={styles.recordValue}>{record.value}</p>
+          </div>
+          {record.is_new_record && <span className={styles.newBadge}>¡Nuevo Record!</span>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/GameDetail/GameDetail.module.css
+++ b/frontend/src/pages/GameDetail/GameDetail.module.css
@@ -1,0 +1,101 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.headerTitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-lg) var(--spacing-md);
+  max-width: 700px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-lg);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent);
+  margin-bottom: var(--spacing-md);
+}
+
+.gameMeta {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--spacing-md);
+}
+
+.rankingList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.rankRow {
+  display: grid;
+  grid-template-columns: 48px 1fr auto auto;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+}
+
+.rankRow.firstPlace {
+  border-color: var(--color-accent);
+  background-color: rgba(230, 126, 34, 0.08);
+}
+
+.position {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-lg);
+}
+
+.firstPlace .position {
+  color: var(--color-accent);
+}
+
+.playerName {
+  font-weight: var(--font-weight-medium);
+}
+
+.points {
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+}
+
+.mc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.errorBox {
+  color: var(--color-error);
+  text-align: center;
+}

--- a/frontend/src/pages/GameDetail/GameDetail.tsx
+++ b/frontend/src/pages/GameDetail/GameDetail.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { getGameResults, getGameRecords } from '@/api/games'
+import { getPlayers } from '@/api/players'
+import { ApiError } from '@/api/client'
+import Button from '@/components/Button/Button'
+import Spinner from '@/components/Spinner/Spinner'
+import RecordsSection from '@/components/RecordsSection/RecordsSection'
+import type { GameResultDTO, GameRecordItemDTO, PlayerResponseDTO } from '@/types'
+import styles from './GameDetail.module.css'
+
+export default function GameDetail() {
+  const { gameId } = useParams<{ gameId: string }>()
+  const [result, setResult] = useState<GameResultDTO | null>(null)
+  const [records, setRecords] = useState<GameRecordItemDTO[] | null>(null)
+  const [players, setPlayers] = useState<PlayerResponseDTO[]>([])
+  const [loadingResults, setLoadingResults] = useState(true)
+  const [loadingRecords, setLoadingRecords] = useState(true)
+  const [recordsUnavailable, setRecordsUnavailable] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!gameId) return
+
+    getGameResults(gameId)
+      .then(setResult)
+      .catch(() => setError('No se pudo cargar el detalle de la partida.'))
+      .finally(() => setLoadingResults(false))
+
+    getGameRecords(gameId)
+      .then((data) => setRecords(data.records))
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) setRecordsUnavailable(true)
+        else setRecordsUnavailable(true)
+      })
+      .finally(() => setLoadingRecords(false))
+
+    getPlayers()
+      .then(setPlayers)
+      .catch(() => {})
+  }, [gameId])
+
+  const playersMap = new Map(players.map((p) => [p.player_id, p.name]))
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link to="/games"><Button variant="ghost" size="sm">← Partidas</Button></Link>
+        <h1 className={styles.headerTitle}>Detalle de partida</h1>
+      </header>
+
+      <main className={styles.main}>
+        {error && <p className={styles.errorBox}>{error}</p>}
+
+        <section className={styles.card}>
+          <h2 className={styles.sectionTitle}>Resultados</h2>
+          {loadingResults && <Spinner />}
+          {!loadingResults && result && (
+            <>
+              <p className={styles.gameMeta}>{result.date}</p>
+              <div className={styles.rankingList}>
+                {result.results.map((r) => (
+                  <div
+                    key={r.player_id}
+                    className={[styles.rankRow, r.position === 1 ? styles.firstPlace : ''].join(' ')}
+                  >
+                    <span className={styles.position}>#{r.position}{r.tied ? ' =' : ''}</span>
+                    <span className={styles.playerName}>
+                      {playersMap.get(r.player_id) ?? r.player_id}
+                    </span>
+                    <span className={styles.points}>{r.total_points} pts</span>
+                    <span className={styles.mc}>MC: {r.mc_total}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </section>
+
+        <section className={styles.card}>
+          <h2 className={styles.sectionTitle}>Records</h2>
+          <RecordsSection
+            records={records}
+            loading={loadingRecords}
+            notAvailable={recordsUnavailable}
+          />
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/GameRecords/GameRecords.module.css
+++ b/frontend/src/pages/GameRecords/GameRecords.module.css
@@ -38,55 +38,6 @@
   color: var(--color-text-muted);
 }
 
-.list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-xl);
-}
-
-.recordItem {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-sm) var(--spacing-md);
-  background-color: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius);
-  gap: var(--spacing-sm);
-}
-
-.recordItem.newRecord {
-  border-color: var(--color-accent);
-  background-color: rgba(230, 126, 34, 0.08);
-}
-
-.recordType {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-}
-
-.recordValue {
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text);
-}
-
-.newBadge {
-  font-size: var(--font-size-sm);
-  background-color: var(--color-accent);
-  color: var(--color-background);
-  padding: 2px var(--spacing-sm);
-  border-radius: var(--border-radius-sm);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
-}
-
-.placeholder {
-  text-align: center;
-  color: var(--color-text-muted);
-  padding: var(--spacing-xl);
-}
-
 .actions {
   display: flex;
   justify-content: center;

--- a/frontend/src/pages/GameRecords/GameRecords.tsx
+++ b/frontend/src/pages/GameRecords/GameRecords.tsx
@@ -3,21 +3,21 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { getGameRecords } from '@/api/games'
 import { ApiError } from '@/api/client'
 import Button from '@/components/Button/Button'
-import Spinner from '@/components/Spinner/Spinner'
-import type { GameRecordsDTO } from '@/types'
+import RecordsSection from '@/components/RecordsSection/RecordsSection'
+import type { GameRecordItemDTO } from '@/types'
 import styles from './GameRecords.module.css'
 
 export default function GameRecords() {
   const { gameId } = useParams<{ gameId: string }>()
   const navigate = useNavigate()
-  const [records, setRecords] = useState<GameRecordsDTO | null>(null)
+  const [records, setRecords] = useState<GameRecordItemDTO[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [notAvailable, setNotAvailable] = useState(false)
 
   useEffect(() => {
     if (!gameId) return
     getGameRecords(gameId)
-      .then(setRecords)
+      .then((data) => setRecords(data.records))
       .catch((err) => {
         if (err instanceof ApiError && err.status === 404) setNotAvailable(true)
         else setNotAvailable(true)
@@ -34,38 +34,7 @@ export default function GameRecords() {
           <p className={styles.subtitle}>Partida #{gameId}</p>
         </div>
 
-        {loading && <Spinner />}
-
-        {!loading && notAvailable && (
-          <div className={styles.placeholder}>
-            <p>Los records de esta partida estarán disponibles próximamente.</p>
-          </div>
-        )}
-
-        {!loading && records && (
-          <>
-            {records.records.length === 0 ? (
-              <div className={styles.placeholder}>
-                <p>No se superaron records en esta partida.</p>
-              </div>
-            ) : (
-              <div className={styles.list}>
-                {records.records.map((record, i) => (
-                  <div
-                    key={i}
-                    className={[styles.recordItem, record.is_new_record ? styles.newRecord : ''].join(' ')}
-                  >
-                    <div>
-                      <p className={styles.recordType}>{record.type}</p>
-                      <p className={styles.recordValue}>{record.value}</p>
-                    </div>
-                    {record.is_new_record && <span className={styles.newBadge}>¡Nuevo Record!</span>}
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
-        )}
+        <RecordsSection records={records} loading={loading} notAvailable={notAvailable} />
 
         <div className={styles.actions}>
           <Button onClick={() => navigate('/home')}>Volver al inicio</Button>

--- a/frontend/src/pages/GamesList/GamesList.module.css
+++ b/frontend/src/pages/GamesList/GamesList.module.css
@@ -1,0 +1,120 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.headerTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+.main {
+  flex: 1;
+  padding: var(--spacing-lg) var(--spacing-md);
+  max-width: 860px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.filtersBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
+  align-items: center;
+}
+
+.select,
+.dateInput {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  color: var(--color-text);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  height: 36px;
+}
+
+.select:focus,
+.dateInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.count {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--spacing-sm);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.listHeader {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 80px;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 80px;
+  gap: var(--spacing-md);
+  align-items: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  text-decoration: none;
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  transition: border-color var(--transition), background-color var(--transition);
+}
+
+.row:hover {
+  border-color: var(--color-accent);
+  background-color: var(--color-surface-hover);
+}
+
+.winner {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent);
+}
+
+.alignCenter {
+  text-align: center;
+}
+
+.empty {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: var(--spacing-2xl);
+}
+
+.errorBox {
+  color: var(--color-error);
+  text-align: center;
+}

--- a/frontend/src/pages/GamesList/GamesList.tsx
+++ b/frontend/src/pages/GamesList/GamesList.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { listGames } from '@/api/games'
+import { getPlayers } from '@/api/players'
+import Button from '@/components/Button/Button'
+import Spinner from '@/components/Spinner/Spinner'
+import { MapName } from '@/constants/enums'
+import { calcRunningTotal } from '@/utils/gameCalculations'
+import type { GameDTO, PlayerResponseDTO } from '@/types'
+import styles from './GamesList.module.css'
+
+interface Filters {
+  map: string
+  playerId: string
+  playerCount: string
+  dateFrom: string
+  dateTo: string
+}
+
+function getWinner(game: GameDTO, playersMap: Map<string, string>): string {
+  if (!game.player_results.length) return '—'
+  const best = game.player_results.reduce((top, curr) =>
+    calcRunningTotal(curr.scores) > calcRunningTotal(top.scores) ? curr : top
+  )
+  return playersMap.get(best.player_id) ?? best.player_id
+}
+
+function applyFilters(games: GameDTO[], players: PlayerResponseDTO[], filters: Filters): GameDTO[] {
+  return games.filter((game) => {
+    if (filters.map && game.map !== filters.map) return false
+    if (filters.playerId && !game.player_results.some((r) => r.player_id === filters.playerId)) return false
+    if (filters.playerCount && game.player_results.length !== Number(filters.playerCount)) return false
+    if (filters.dateFrom && game.date < filters.dateFrom) return false
+    if (filters.dateTo && game.date > filters.dateTo) return false
+    return true
+  })
+}
+
+export default function GamesList() {
+  const [games, setGames] = useState<GameDTO[]>([])
+  const [players, setPlayers] = useState<PlayerResponseDTO[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [showFilters, setShowFilters] = useState(false)
+  const [filters, setFilters] = useState<Filters>({
+    map: '',
+    playerId: '',
+    playerCount: '',
+    dateFrom: '',
+    dateTo: '',
+  })
+
+  useEffect(() => {
+    Promise.all([listGames(), getPlayers()])
+      .then(([gamesData, playersData]) => {
+        setGames(gamesData)
+        setPlayers(playersData)
+      })
+      .catch(() => setError('No se pudieron cargar las partidas.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const playersMap = useMemo(
+    () => new Map(players.map((p) => [p.player_id, p.name])),
+    [players]
+  )
+
+  const filtered = useMemo(
+    () => applyFilters(games, players, filters),
+    [games, players, filters]
+  )
+
+  const setFilter = (key: keyof Filters) => (e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement>) => {
+    setFilters((prev) => ({ ...prev, [key]: e.target.value }))
+  }
+
+  const clearFilters = () =>
+    setFilters({ map: '', playerId: '', playerCount: '', dateFrom: '', dateTo: '' })
+
+  const activeFilterCount = Object.values(filters).filter(Boolean).length
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.headerLeft}>
+          <Link to="/home"><Button variant="ghost" size="sm">← Inicio</Button></Link>
+          <h1 className={styles.headerTitle}>Partidas</h1>
+        </div>
+        <Button variant="ghost" size="sm" onClick={() => setShowFilters((v) => !v)}>
+          Filtros{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+        </Button>
+      </header>
+
+      <main className={styles.main}>
+        {showFilters && (
+          <div className={styles.filtersBar}>
+            <select className={styles.select} value={filters.map} onChange={setFilter('map')}>
+              <option value="">Todos los mapas</option>
+              {Object.values(MapName).map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+
+            <select className={styles.select} value={filters.playerId} onChange={setFilter('playerId')}>
+              <option value="">Todos los jugadores</option>
+              {players.map((p) => (
+                <option key={p.player_id} value={p.player_id}>{p.name}</option>
+              ))}
+            </select>
+
+            <select className={styles.select} value={filters.playerCount} onChange={setFilter('playerCount')}>
+              <option value="">Cantidad de jugadores</option>
+              {[2, 3, 4, 5].map((n) => (
+                <option key={n} value={n}>{n} jugadores</option>
+              ))}
+            </select>
+
+            <input
+              type="date"
+              className={styles.dateInput}
+              value={filters.dateFrom}
+              onChange={setFilter('dateFrom')}
+            />
+            <input
+              type="date"
+              className={styles.dateInput}
+              value={filters.dateTo}
+              onChange={setFilter('dateTo')}
+            />
+
+            {activeFilterCount > 0 && (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>Limpiar</Button>
+            )}
+          </div>
+        )}
+
+        {loading && <Spinner />}
+        {error && <p className={styles.errorBox}>{error}</p>}
+
+        {!loading && !error && (
+          <>
+            <p className={styles.count}>{filtered.length} partida{filtered.length !== 1 ? 's' : ''}</p>
+
+            {filtered.length === 0 ? (
+              <p className={styles.empty}>No hay partidas que coincidan con los filtros.</p>
+            ) : (
+              <div className={styles.list}>
+                <div className={styles.listHeader}>
+                  <span>Fecha</span>
+                  <span>Ganador</span>
+                  <span>Mapa</span>
+                  <span className={styles.alignCenter}>Jugadores</span>
+                </div>
+                {filtered.map((game) => (
+                  <Link
+                    key={game.id}
+                    to={`/games/${game.id}`}
+                    className={styles.row}
+                  >
+                    <span>{game.date}</span>
+                    <span className={styles.winner}>{getWinner(game, playersMap)}</span>
+                    <span>{game.map}</span>
+                    <span className={styles.alignCenter}>{game.player_results.length}</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -6,6 +6,7 @@ import styles from './Home.module.css'
 const navItems = [
   { to: '/players', icon: '👥', title: 'Jugadores', description: 'Gestión de jugadores', disabled: false },
   { to: '/games/new', icon: '🎯', title: 'Cargar Partida', description: 'Registrar nueva partida', disabled: false },
+  { to: '/games', icon: '📋', title: 'Partidas', description: 'Historial de partidas', disabled: false },
   { to: '/records', icon: '🏆', title: 'Records', description: 'Próximamente', disabled: true },
 ]
 

--- a/frontend/src/pages/PlayerProfile/PlayerProfile.module.css
+++ b/frontend/src/pages/PlayerProfile/PlayerProfile.module.css
@@ -1,0 +1,157 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.headerTitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-lg) var(--spacing-md);
+  max-width: 700px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.statsCard {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-lg);
+}
+
+.section {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-lg);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--spacing-md);
+  color: var(--color-accent);
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-md);
+  text-align: center;
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.statValue {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-accent);
+}
+
+.statLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.gameList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.gameRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  text-decoration: none;
+  color: var(--color-text);
+  transition: border-color var(--transition), background-color var(--transition);
+}
+
+.gameRow:hover {
+  border-color: var(--color-accent);
+  background-color: var(--color-surface-hover);
+}
+
+.gameDate {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.gamePosition {
+  font-weight: var(--font-weight-bold);
+  min-width: 32px;
+  text-align: center;
+}
+
+.gamePosition.winner {
+  color: var(--color-accent);
+}
+
+.gamePoints {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  min-width: 60px;
+  text-align: right;
+}
+
+.recordList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.recordItem {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: rgba(230, 126, 34, 0.08);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--border-radius);
+}
+
+.recordIcon {
+  font-size: var(--font-size-lg);
+}
+
+.recordType {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.errorBox {
+  color: var(--color-error);
+  text-align: center;
+}

--- a/frontend/src/pages/PlayerProfile/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile/PlayerProfile.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { getPlayerProfile, getPlayers } from '@/api/players'
+import Button from '@/components/Button/Button'
+import Spinner from '@/components/Spinner/Spinner'
+import type { PlayerProfileDTO } from '@/types'
+import styles from './PlayerProfile.module.css'
+
+export default function PlayerProfile() {
+  const { playerId } = useParams<{ playerId: string }>()
+  const [profile, setProfile] = useState<PlayerProfileDTO | null>(null)
+  const [playerName, setPlayerName] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!playerId) return
+    Promise.all([getPlayerProfile(playerId), getPlayers()])
+      .then(([profileData, playersData]) => {
+        setProfile(profileData)
+        const found = playersData.find((p) => p.player_id === playerId)
+        setPlayerName(found?.name ?? playerId)
+      })
+      .catch(() => setError('No se pudo cargar el perfil del jugador.'))
+      .finally(() => setLoading(false))
+  }, [playerId])
+
+  const activeRecords = profile
+    ? Object.entries(profile.records).filter(([, holds]) => holds)
+    : []
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link to="/players">
+          <Button variant="ghost" size="sm">← Jugadores</Button>
+        </Link>
+        <h1 className={styles.headerTitle}>
+          {playerName || 'Perfil'}
+        </h1>
+      </header>
+
+      <main className={styles.main}>
+        {loading && <Spinner />}
+        {error && <p className={styles.errorBox}>{error}</p>}
+
+        {!loading && profile && (
+          <>
+            <section className={styles.statsCard}>
+              <h2 className={styles.sectionTitle}>Estadísticas</h2>
+              <div className={styles.statsGrid}>
+                <div className={styles.statItem}>
+                  <span className={styles.statValue}>{profile.stats.games_played}</span>
+                  <span className={styles.statLabel}>Partidas jugadas</span>
+                </div>
+                <div className={styles.statItem}>
+                  <span className={styles.statValue}>{profile.stats.games_won}</span>
+                  <span className={styles.statLabel}>Partidas ganadas</span>
+                </div>
+                <div className={styles.statItem}>
+                  <span className={styles.statValue}>
+                    {(profile.stats.win_rate * 100).toFixed(0)}%
+                  </span>
+                  <span className={styles.statLabel}>Win rate</span>
+                </div>
+              </div>
+            </section>
+
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Historial de partidas</h2>
+              {profile.games.length === 0 ? (
+                <p className={styles.empty}>Todavía no hay partidas registradas.</p>
+              ) : (
+                <div className={styles.gameList}>
+                  {profile.games.map((game) => (
+                    <Link
+                      key={game.game_id}
+                      to={`/games/${game.game_id}`}
+                      className={styles.gameRow}
+                    >
+                      <span className={styles.gameDate}>{game.date}</span>
+                      <span className={[styles.gamePosition, game.position === 1 ? styles.winner : ''].join(' ')}>
+                        #{game.position}
+                      </span>
+                      <span className={styles.gamePoints}>{game.points} pts</span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Records actuales</h2>
+              {activeRecords.length === 0 ? (
+                <p className={styles.empty}>Este jugador no sostiene ningún record actualmente.</p>
+              ) : (
+                <div className={styles.recordList}>
+                  {activeRecords.map(([type]) => (
+                    <div key={type} className={styles.recordItem}>
+                      <span className={styles.recordIcon}>🏅</span>
+                      <span className={styles.recordType}>{type}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/Players/Players.module.css
+++ b/frontend/src/pages/Players/Players.module.css
@@ -93,6 +93,13 @@
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   gap: var(--spacing-sm);
+  cursor: pointer;
+  transition: border-color var(--transition), background-color var(--transition);
+}
+
+.playerCard:hover {
+  border-color: var(--color-accent);
+  background-color: var(--color-surface-hover);
 }
 
 .playerInfo {
@@ -108,6 +115,13 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  color: var(--color-text);
+  text-decoration: none;
+  transition: color var(--transition);
+}
+
+.playerName:hover {
+  color: var(--color-accent);
 }
 
 .statusBadge {

--- a/frontend/src/pages/Players/Players.tsx
+++ b/frontend/src/pages/Players/Players.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { usePlayers } from '@/hooks/usePlayers'
 import Button from '@/components/Button/Button'
 import Spinner from '@/components/Spinner/Spinner'
@@ -11,10 +11,11 @@ import styles from './Players.module.css'
 interface PlayerFormProps {
   player?: PlayerResponseDTO
   onSave: (name: string) => Promise<void>
+  onToggleActive?: () => Promise<void>
   onCancel: () => void
 }
 
-function PlayerForm({ player, onSave, onCancel }: PlayerFormProps) {
+function PlayerForm({ player, onSave, onToggleActive, onCancel }: PlayerFormProps) {
   const [name, setName] = useState(player?.name ?? '')
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
@@ -26,6 +27,16 @@ function PlayerForm({ player, onSave, onCancel }: PlayerFormProps) {
       await onSave(name.trim())
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al guardar')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleToggleActive = async () => {
+    if (!onToggleActive) return
+    setSaving(true)
+    try {
+      await onToggleActive()
     } finally {
       setSaving(false)
     }
@@ -43,6 +54,11 @@ function PlayerForm({ player, onSave, onCancel }: PlayerFormProps) {
         onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit() }}
       />
       <div className={styles.formActions}>
+        {onToggleActive && (
+          <Button variant="danger" onClick={handleToggleActive} disabled={saving}>
+            {player?.is_active ? 'Desactivar' : 'Activar'}
+          </Button>
+        )}
         <Button variant="ghost" onClick={onCancel} disabled={saving}>Cancelar</Button>
         <Button onClick={handleSubmit} disabled={saving}>
           {saving ? 'Guardando...' : 'Guardar'}
@@ -53,6 +69,7 @@ function PlayerForm({ player, onSave, onCancel }: PlayerFormProps) {
 }
 
 export default function Players() {
+  const navigate = useNavigate()
   const [activeOnly, setActiveOnly] = useState(true)
   const { players, loading, error, addPlayer, editPlayer } = usePlayers({ activeOnly })
   const [showCreate, setShowCreate] = useState(false)
@@ -69,8 +86,10 @@ export default function Players() {
     setEditing(null)
   }
 
-  const handleToggleActive = async (player: PlayerResponseDTO) => {
-    await editPlayer(player.player_id, { is_active: !player.is_active })
+  const handleToggleActive = async () => {
+    if (!editing) return
+    await editPlayer(editing.player_id, { is_active: !editing.is_active })
+    setEditing(null)
   }
 
   return (
@@ -105,23 +124,17 @@ export default function Players() {
 
         <div className={styles.list}>
           {players.map((player) => (
-            <div key={player.player_id} className={styles.playerCard}>
+            <div
+              key={player.player_id}
+              className={styles.playerCard}
+              onClick={() => navigate(`/players/${player.player_id}/profile`)}
+            >
               <div className={styles.playerInfo}>
                 <span className={styles.playerName}>{player.name}</span>
-                <span className={[styles.statusBadge, player.is_active ? styles.active : styles.inactive].join(' ')}>
-                  {player.is_active ? 'Activo' : 'Inactivo'}
-                </span>
               </div>
-              <div className={styles.actions}>
+              <div className={styles.actions} onClick={(e) => e.stopPropagation()}>
                 <Button variant="ghost" size="sm" onClick={() => setEditing(player)}>
                   Editar
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleToggleActive(player)}
-                >
-                  {player.is_active ? 'Desactivar' : 'Activar'}
                 </Button>
               </div>
             </div>
@@ -137,7 +150,12 @@ export default function Players() {
 
       {editing && (
         <Modal title="Editar jugador" onClose={() => setEditing(null)}>
-          <PlayerForm player={editing} onSave={handleEdit} onCancel={() => setEditing(null)} />
+          <PlayerForm
+            player={editing}
+            onSave={handleEdit}
+            onToggleActive={handleToggleActive}
+            onCancel={() => setEditing(null)}
+          />
         </Modal>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Player profile**: clicking a player's name in the list navigates to a dedicated profile screen showing stats (games played/won, win rate), game history with links to each game detail, and current records held
- **Games history**: new home option listing all recorded games with collapsible filters (map, player, player count, date range) and a detail screen showing results ranking + records per game
- **Shared `RecordsSection` component**: extracted from `GameRecords` and reused in the new `GameDetail` page
- **UX improvements**: player card is fully clickable to navigate to the profile; Deactivate action moved into the edit modal; game filters are hidden by default behind a toggle button

## New routes

| Path | Component |
|---|---|
| `/players/:playerId/profile` | `PlayerProfile` |
| `/games` | `GamesList` |
| `/games/:gameId` | `GameDetail` |

## New API functions

- `getPlayerProfile(playerId)` → `GET /players/{id}/profile`
- `listGames()` → `GET /games/`
- `getGameResults(gameId)` → `GET /games/{id}/results`

## Test plan

- [ ] Navegar a `/players` → click en nombre de jugador → verificar que el perfil muestra nombre, stats, historial y records correctos
- [ ] Desde el perfil, click en una partida → navega a `/games/:gameId`
- [ ] `/home` → nueva card "Partidas" → navega a `/games`
- [ ] En `/games`, toggle "Filtros" → el panel muestra/oculta; aplicar filtros y verificar que los resultados se actualizan client-side
- [ ] Click en fila de partida → detalle muestra ranking y sección de records
- [ ] Modal de edición de jugador → botón Desactivar/Activar presente y funcional
- [ ] Flujo post-carga de partida (`GameRecords`) sigue funcionando correctamente