### PR TITLE
feat: dockerize all services + CI/CD pipeline for production deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,13 @@
-# copy this file to .env and edit if needed
+# Copy this file to .env and edit as needed
+
+# --- Backend ---
+# Database connection (local dev uses Docker Compose defaults)
 DATABASE_URL=postgresql://tm_user:tm_pass@localhost:5432/tm_scorekeeper
+
+# CORS: URL of the frontend (used by FastAPI to allow cross-origin requests)
+FRONTEND_URL=http://localhost:5173
+
+# --- Frontend (only needed for production) ---
+# When set, the API client calls this URL directly instead of using the /api proxy.
+# Leave empty for local dev.
+# VITE_API_URL=https://tm-scorekeeper-backend.onrender.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: CI / Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, staging]
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: tm_user
+          POSTGRES_PASSWORD: tm_pass
+          POSTGRES_DB: tm_scorekeeper
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: python -m pytest backend/tests -q
+        env:
+          DATABASE_URL: postgresql://tm_user:tm_pass@localhost:5432/tm_scorekeeper
+
+  test-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+        working-directory: frontend
+      - run: npm test -- --run
+        working-directory: frontend
+
+  migrate-and-deploy:
+    needs: [test-backend, test-frontend]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - name: Run migrations
+        run: alembic upgrade head
+        working-directory: backend
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - name: Trigger Render deploy
+        run: curl -fsSX POST "${{ secrets.RENDER_DEPLOY_HOOK }}"

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Source code is mounted as a volume in dev (hot-reload via --reload)
+# For production builds, copy source here instead
+CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies first (better layer caching)
+COPY frontend/package*.json ./
+RUN npm install
+
+# Source code is mounted as a volume in dev (hot-reload via vite)
+# For production builds, copy source and run `npm run build` instead
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: dev down migrate logs test-backend test-frontend
+
+dev:
+	docker compose up --build
+
+down:
+	docker compose down
+
+migrate:
+	docker compose exec backend alembic upgrade head
+
+logs:
+	docker compose logs -f
+
+test-backend:
+	docker compose exec backend python -m pytest tests -q
+
+test-frontend:
+	docker compose exec frontend npm test -- --run

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import os
+
+# Ensure the backend directory is on sys.path so imports work whether
+# pytest is invoked from the repo root (CI) or from within backend/ (Docker).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,18 @@
+import os
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from routes.games_routes import router as games_router
 from routes.players_routes import router as players_router
 
 app = FastAPI(title="Terraforming Mars API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[os.getenv("FRONTEND_URL", "http://localhost:5173")],
+    allow_methods=["*"],
+    allow_headers=["*"],
+    allow_credentials=True,
+)
 
 app.include_router(games_router)
 app.include_router(players_router)

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -1,16 +1,9 @@
-import os, sys
 import pytest
 
-# make backend directory importable (routes etc. are top-level inside it)
-workspace_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
-backend_dir = os.path.join(workspace_root, "backend")
-if backend_dir not in sys.path:
-    sys.path.insert(0, backend_dir)
-
 from fastapi.testclient import TestClient
-from backend.main import app
-from backend.db.models import Base
-from backend.db.session import engine
+from main import app
+from db.models import Base
+from db.session import engine
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -28,17 +21,17 @@ def client():
 
 @pytest.fixture
 def session_factory():
-    from backend.db.session import get_session
+    from db.session import get_session
     return get_session
 
 
 @pytest.fixture
 def players_repo(session_factory):
-    from backend.repositories.player_repository import PlayersRepository
+    from repositories.player_repository import PlayersRepository
     return PlayersRepository(session_factory=session_factory)
 
 
 @pytest.fixture
 def games_repo(session_factory):
-    from backend.repositories.game_repository import GamesRepository
+    from repositories.game_repository import GamesRepository
     return GamesRepository(session_factory=session_factory)

--- a/backend/tests/e2e/test_api.py
+++ b/backend/tests/e2e/test_api.py
@@ -3,11 +3,11 @@ from datetime import date
 
 import pytest
 
-from backend.models.player import Player
-from backend.mappers.game_mapper import game_dto_to_model
-from backend.schemas.game import GameDTO
-from backend.schemas.player import PlayerResultDTO, PlayerScoreDTO, PlayerEndStatsDTO
-from backend.models.enums import Corporation, MapName
+from models.player import Player
+from mappers.game_mapper import game_dto_to_model
+from schemas.game import GameDTO
+from schemas.player import PlayerResultDTO, PlayerScoreDTO, PlayerEndStatsDTO
+from models.enums import Corporation, MapName
 
 
 def test_create_game_and_query_results(client, players_repo):
@@ -66,8 +66,8 @@ def test_player_profile_endpoint(client, players_repo, games_repo):
     players_repo.create(Player(player_id="p3", name="Carol"))
 
     # create a game domain object and persist it via repository
-    from backend.models.game import Game
-    from backend.models.player_result import PlayerResult, PlayerScore, PlayerEndStats
+    from models.game import Game
+    from models.player_result import PlayerResult, PlayerScore, PlayerEndStats
 
     game = Game(
         game_id=None,

--- a/backend/tests/test_enums.py
+++ b/backend/tests/test_enums.py
@@ -4,21 +4,16 @@ from models.enums import Corporation
 
 def test_milestone_enum_contract():
     expected = {
-        "Terraformer",
-        "Mayor",
-        "Gardener",
-        "Builder",
-        "Planner",
-        "Generalist",
-        "Specialist",
-        "Ecologist",
-        "Tycoon",
-        "Legend",
-        "Diversifier",
-        "Tactician",
-        "Polar Explorer",
-        "Energizer",
-        "Rim Settler",
+        # Tharsis
+        "Terraformer", "Mayor", "Gardener", "Builder", "Planner",
+        # Elysium
+        "Generalist", "Specialist", "Ecologist", "Tycoon", "Legend",
+        # Hellas
+        "Diversifier", "Tactician", "Polar Explorer", "Energizer", "Rim Settler",
+        # Vastitas Borealis
+        "Agronomist", "Engineer", "Spacecrafter", "Geologist", "Farmer",
+        # Amazonis Planitia
+        "Terran", "Landshaper", "Merchant", "Sponsor", "Lobbyist",
     }
 
     actual = {m.value for m in Milestone}
@@ -27,21 +22,16 @@ def test_milestone_enum_contract():
 
 def test_award_enum_contract():
     expected = {
-        "Terraformer",
-        "Mayor",
-        "Gardener",
-        "Builder",
-        "Planner",
-        "Cultivator",
-        "Magnate",
-        "Space Baron",
-        "Excentric",
-        "Contractor",
-        "Celebrity",
-        "Industrialist",
-        "Desert Settler",
-        "Estate Dealer",
-        "Benefactor",
+        # Tharsis
+        "Landlord", "Banker", "Scientist", "Thermalist", "Miner",
+        # Hellas
+        "Cultivator", "Magnate", "Space Baron", "Excentric", "Contractor",
+        # Elysium
+        "Celebrity", "Industrialist", "Desert Settler", "Estate Dealer", "Benefactor",
+        # Vastitas Borealis
+        "Traveller", "Landscaper", "Highlander", "Promoter", "Blacksmith",
+        # Amazonis Planitia
+        "Collector", "Innovator", "Constructor", "Manufacturer", "Physicist",
     }
 
     actual = {a.value for a in Award}

--- a/backend/tests/test_player_profile.py
+++ b/backend/tests/test_player_profile.py
@@ -13,9 +13,8 @@ from db.models import Base
 from db.session import engine
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def setup_db():
-    # create / drop tables around the test module
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)
@@ -57,7 +56,7 @@ def player_profile_service(players_repo, games_repo):
 
 def test_player_with_no_games_has_zero_stats(player_profile_service, players_repo):
     # arrange: register player but do not insert any game
-    players_repo.register_player(Player(player_id="p1", name="Test", is_active=True))
+    players_repo.create(Player(player_id="p1", name="Test", is_active=True))
 
     profile = player_profile_service.get_profile("p1")
 
@@ -71,8 +70,9 @@ def test_player_with_no_games_has_zero_stats(player_profile_service, players_rep
 def test_player_with_one_winning_game_has_100_percent_win_rate(
     player_profile_service, players_repo, games_repo
 ):
-    # prepare player
-    players_repo.register_player(Player(player_id="p1", name="Test", is_active=True))
+    # prepare players
+    players_repo.create(Player(player_id="p1", name="Test", is_active=True))
+    players_repo.create(Player(player_id="p2", name="Opponent", is_active=True))
 
     player_pl = PlayerResultDTO(
         player_id="p1",
@@ -135,7 +135,9 @@ def test_player_with_one_winning_game_has_100_percent_win_rate(
 def test_player_with_multiple_games_and_one_win_has_correct_win_rate(
     player_profile_service, players_repo, games_repo
 ):
-    players_repo.register_player(Player(player_id="p1", name="Test", is_active=True))
+    players_repo.create(Player(player_id="p1", name="Test", is_active=True))
+    players_repo.create(Player(player_id="p2", name="Opponent", is_active=True))
+    players_repo.create(Player(player_id="p3", name="Third", is_active=True))
 
     base_player = PlayerResultDTO(
         player_id="p1",

--- a/backend/tests/test_records.py
+++ b/backend/tests/test_records.py
@@ -14,7 +14,7 @@ from db.models import Base
 from db.session import engine
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def setup_db():
     Base.metadata.create_all(bind=engine)
     yield
@@ -31,6 +31,12 @@ def session_factory():
 def games_repo(session_factory):
     from repositories.game_repository import GamesRepository
     return GamesRepository(session_factory=session_factory)
+
+
+@pytest.fixture
+def players_repo(session_factory):
+    from repositories.player_repository import PlayersRepository
+    return PlayersRepository(session_factory=session_factory)
 
 
 def make_player(player_id: str) -> PlayerResult:
@@ -65,12 +71,21 @@ def make_game(game_id: str, players: list[PlayerResult]) -> Game:
     )
 
 
-def persist_games(games: list[Game], repo):
+def persist_games(games: list[Game], repo, players_repo):
+    seen: set[str] = set()
     for g in games:
+        for pr in g.player_results:
+            if pr.player_id not in seen:
+                from models.player import Player
+                try:
+                    players_repo.create(Player(player_id=pr.player_id, name=pr.player_id, is_active=True))
+                except ValueError:
+                    pass
+                seen.add(pr.player_id)
         repo.create(g)
 
 
-def test_most_games_played(games_repo):
+def test_most_games_played(games_repo, players_repo):
     p1 = make_player("p1")
     p2 = make_player("p2")
 
@@ -79,7 +94,7 @@ def test_most_games_played(games_repo):
     game3 = make_game("g3", [p2])
     game4 = make_game("g4", [p1])
 
-    persist_games([game1, game2, game3, game4], games_repo)
+    persist_games([game1, game2, game3, game4], games_repo, players_repo)
 
     service = RecordsService(games_repo)
     record = service.most_games_played()
@@ -92,7 +107,7 @@ def test_most_games_played(games_repo):
     assert record.game_id is None
 
 
-def test_most_games_won(games_repo):
+def test_most_games_won(games_repo, players_repo):
     game1 = make_game("g1", [make_player("p1"), make_player("p2")])
     game1.player_results[0].scores.terraform_rating = 30
     game1.player_results[1].scores.terraform_rating = 20
@@ -111,7 +126,7 @@ def test_most_games_won(games_repo):
     game4.player_results[0].end_stats.mc_total = 10
     game4.player_results[1].end_stats.mc_total = 10
 
-    persist_games([game1, game2, game3, game4], games_repo)
+    persist_games([game1, game2, game3, game4], games_repo, players_repo)
 
     service = RecordsService(games_repo)
     record = service.most_games_won()
@@ -124,7 +139,7 @@ def test_most_games_won(games_repo):
     assert record.game_id is None
 
 
-def test_highest_single_game_score(games_repo):
+def test_highest_single_game_score(games_repo, players_repo):
     game1 = make_game("g1", [make_player("p1"), make_player("p2")])
     game1.player_results[0].scores.terraform_rating = 70
     game1.player_results[1].scores.terraform_rating = 60
@@ -137,7 +152,7 @@ def test_highest_single_game_score(games_repo):
     game3.player_results[0].scores.terraform_rating = 65
     game3.player_results[1].scores.terraform_rating = 50
 
-    persist_games([game1, game2, game3], games_repo)
+    persist_games([game1, game2, game3], games_repo, players_repo)
 
     service = RecordsService(games_repo)
     record = service.highest_single_game_score()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     image: postgres:15
@@ -9,9 +7,43 @@ services:
       POSTGRES_PASSWORD: tm_pass
       POSTGRES_DB: tm_scorekeeper
     ports:
-      - "5432:5432"             # map to localhost for tests and dev tools
+      - "5432:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tm_user -d tm_scorekeeper"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    environment:
+      DATABASE_URL: postgresql://tm_user:tm_pass@db:5432/tm_scorekeeper
+      FRONTEND_URL: http://localhost:5173
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules  # keep container's node_modules, don't override with host
+    environment:
+      BACKEND_URL: http://backend:8000
+    depends_on:
+      - backend
 
 volumes:
   db_data:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,6 @@
-const BASE_URL = '/api'
+// Dev: VITE_API_URL undefined → '/api' → vite proxy strips prefix → backend local
+// Prod: VITE_API_URL = 'https://backend.onrender.com' → llamadas directas
+const BASE_URL = import.meta.env.VITE_API_URL ?? '/api'
 
 export class ApiError extends Error {
   constructor(

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: process.env.BACKEND_URL ?? 'http://localhost:8000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: web
+    name: tm-scorekeeper-backend
+    runtime: python
+    rootDir: backend
+    buildCommand: pip install -r ../requirements.txt
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: DATABASE_URL
+        sync: false   # set manually in Render dashboard (Supabase connection string)
+      - key: FRONTEND_URL
+        sync: false   # set manually in Render dashboard (Vercel URL)
+      - key: PYTHON_VERSION
+        value: "3.12.0"


### PR DESCRIPTION
## Motivation

Previously, running the app locally required starting 3 services manually with separate scripts. There was also no automated path to deploy to production. This PR addresses both.

---

## What changed

### Local development — single command startup

`docker compose up --build` now starts all 3 services together with hot-reload:

| Service | Port | Hot-reload |
|---|---|---|
| PostgreSQL | 5432 | — |
| FastAPI backend | 8000 | ✅ uvicorn --reload + mounted volume |
| Vite frontend | 5173 | ✅ vite dev + mounted volume |

A `Makefile` provides ergonomic shortcuts:

```bash
make dev          # docker compose up --build
make down         # docker compose down
make migrate      # alembic upgrade head (inside backend container)
make logs         # follow all container logs
make test-backend # pytest inside container
make test-frontend # vitest inside container
```

### Production readiness

| File | Change |
|---|---|
| `backend/main.py` | CORS middleware reads `FRONTEND_URL` from env (required for Vercel ↔ Render cross-origin calls) |
| `frontend/src/api/client.ts` | Base URL reads from `VITE_API_URL` env var; falls back to `/api` proxy in dev |
| `frontend/vite.config.ts` | Proxy target reads from `BACKEND_URL` env var (Docker uses `http://backend:8000` instead of `localhost`) |
| `render.yaml` | Render infrastructure-as-code for backend deployment (Python web service) |
| `frontend/vercel.json` | Vercel build config for Vite SPA |
| `.env.example` | Updated with all required variables |

### CI/CD pipeline (`.github/workflows/deploy.yml`)

```
PR to main/staging
  ├── test-backend  (pytest with ephemeral Postgres service)
  └── test-frontend (vitest --run)

Merge to main
  └── migrate-and-deploy
        ├── alembic upgrade head → Supabase (production DB)
        └── curl RENDER_DEPLOY_HOOK → triggers Render redeploy
```

Vercel auto-deploys independently on every push to `main`.

---

## Setup checklist (one-time, before first deploy to main)

- [ ] Create Supabase project → copy connection string
- [ ] Create Render Web Service from GitHub repo → set env vars (`DATABASE_URL`, `FRONTEND_URL`)
- [ ] Create Vercel project from GitHub repo → set env var (`VITE_API_URL`)
- [ ] Add GitHub Secrets: `DATABASE_URL` (Supabase) and `RENDER_DEPLOY_HOOK` (Render)