### PR TITLE
fix: typecheck en CI + corrección errores TS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
           node-version: "20"
       - run: npm ci
         working-directory: frontend
+      - run: npm run typecheck
+        working-directory: frontend
       - run: npm test -- --run
         working-directory: frontend
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev down migrate logs test-backend test-frontend
+.PHONY: dev down migrate logs test-backend test-frontend typechecks
 
 dev:
 	docker compose up --build
@@ -17,3 +17,6 @@ test-backend:
 
 test-frontend:
 	docker compose exec frontend npm test -- --run
+
+typechecks:
+	docker compose exec frontend npm run typecheck

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/frontend/src/pages/GamesList/GamesList.tsx
+++ b/frontend/src/pages/GamesList/GamesList.tsx
@@ -25,7 +25,7 @@ function getWinner(game: GameDTO, playersMap: Map<string, string>): string {
   return playersMap.get(best.player_id) ?? best.player_id
 }
 
-function applyFilters(games: GameDTO[], players: PlayerResponseDTO[], filters: Filters): GameDTO[] {
+function applyFilters(games: GameDTO[], _players: PlayerResponseDTO[], filters: Filters): GameDTO[] {
   return games.filter((game) => {
     if (filters.map && game.map !== filters.map) return false
     if (filters.playerId && !game.player_results.some((r) => r.player_id === filters.playerId)) return false

--- a/frontend/src/test/e2e/full-flow.spec.ts
+++ b/frontend/src/test/e2e/full-flow.spec.ts
@@ -1,19 +1,10 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
 /**
  * E2E: Full flow test
  * Requires backend running on localhost:8000 and frontend on localhost:5173.
  * Tests: login → navigate → players page → game form entry
  */
-
-async function loginToApp(page: Page) {
-  await page.evaluate(() => localStorage.clear())
-  await page.goto('/login')
-  await page.fill('input[type="text"]', 'admin')
-  await page.fill('input[type="password"]', 'admin')
-  await page.click('button[type="submit"]')
-  await expect(page).toHaveURL('/home')
-}
 
 test.describe('Full flow integration', () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary

- Agrega `npm run typecheck` (`tsc -b`) como step en el job `test-frontend` de CI, para detectar errores de TypeScript antes del deploy a Vercel
- Agrega script `typecheck` en `frontend/package.json` y target `make typechecks` para correrlo localmente
- Corrige los 2 errores TS que bloqueaban el build de Vercel:
  - `GamesList.tsx`: parámetro `players` no usado → renombrado a `_players`
  - `full-flow.spec.ts`: función `loginToApp` y su import `Page` eran dead code → eliminados

## Test plan

- [ ] `make typechecks` pasa sin errores
- [ ] CI pipeline verde en esta PR (step `npm run typecheck` visible en job `test-frontend`)
- [ ] Build de Vercel no falla por errores TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)