### PR TITLE
Fix/allow multiple novel corporations

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -5,6 +5,9 @@ WORKDIR /app
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY backend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Source code is mounted as a volume in dev (hot-reload via --reload)
 # For production builds, copy source here instead
-CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ logs:
 	docker compose logs -f
 
 test-backend:
-	docker compose exec backend python -m pytest tests -q
+	docker compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.test.yml run --rm --build backend_test
+	docker compose -f docker-compose.test.yml down
 
 test-frontend:
 	docker compose exec frontend npm test -- --run

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+alembic upgrade head
+
+if [ "$SEED_DATA" = "true" ]; then
+    echo "Seeding initial data..."
+    python scripts/seed.py
+fi
+
+echo "Starting server..."
+exec uvicorn main:app --reload --host 0.0.0.0 --port 8000

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -1,0 +1,29 @@
+"""
+Seed script for local development.
+Creates initial players if they don't already exist.
+Run via entrypoint.sh when SEED_DATA=true.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from db.session import get_session
+from db.models import Player as PlayerORM
+
+SEED_PLAYERS = ["Facu", "Bru", "Marian", "Efra", "Clau", "Albert"]
+
+with get_session() as session:
+    existing_names = {p.name for p in session.query(PlayerORM).all()}
+    added = []
+    for name in SEED_PLAYERS:
+        if name not in existing_names:
+            from uuid import uuid4
+            session.add(PlayerORM(id=str(uuid4()), name=name, is_active=True))
+            added.append(name)
+    session.commit()
+
+if added:
+    print(f"Seeded players: {', '.join(added)}")
+else:
+    print("Seed players already exist, skipping.")

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -2,6 +2,7 @@ from models.player_result import PlayerResult
 from schemas.game import GameDTO
 from datetime import date
 from models.award_result import AwardResult
+from models.enums import Corporation
 from services.results import calculate_results
 from schemas.result import GameResultDTO
 from mappers.game_mapper import game_dto_to_model
@@ -28,12 +29,18 @@ class GamesService:
             raise ValueError("Duplicate players are not allowed")
         
     def _validate_corporations(self, players: list[PlayerResult]) -> None:
+        seen: set = set()
         for player in players:
             corp = player.corporation
-            # corporation may be an enum or a string; ensure it is not empty
             if not corp or not str(corp).strip():
                 raise ValueError(
                     f"Player '{player.player_id}' must have a non-empty corporation")
+            if corp == Corporation.NOVEL:
+                continue  # NOVEL can be chosen by multiple players
+            if corp in seen:
+                raise ValueError(
+                    f"Corporation '{corp}' was chosen by more than one player")
+            seen.add(corp)
     
     def _validate_milestones(self, players: list[PlayerResult]) -> None:
         total = sum(len(player.scores.milestones) for player in players)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from db.models import Base
+from db.session import engine
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def clean_tables():
+    yield
+    with engine.begin() as conn:
+        for table in reversed(Base.metadata.sorted_tables):
+            conn.execute(table.delete())

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -2,16 +2,6 @@ import pytest
 
 from fastapi.testclient import TestClient
 from main import app
-from db.models import Base
-from db.session import engine
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_db():
-    # Ensure tables exist (no-op if already created by migrations)
-    Base.metadata.create_all(bind=engine)
-    yield
-    # Do NOT drop tables — this would destroy the dev/CI database schema
 
 
 @pytest.fixture

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -8,10 +8,10 @@ from db.session import engine
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_db():
-    # create and later drop tables against whatever DATABASE_URL is configured
+    # Ensure tables exist (no-op if already created by migrations)
     Base.metadata.create_all(bind=engine)
     yield
-    Base.metadata.drop_all(bind=engine)
+    # Do NOT drop tables — this would destroy the dev/CI database schema
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_player_profile.py
+++ b/backend/tests/integration/test_player_profile.py
@@ -8,18 +8,6 @@ from mappers.game_mapper import game_dto_to_model
 
 import pytest
 
-# database fixtures
-from db.models import Base
-from db.session import engine
-
-
-@pytest.fixture(scope="function", autouse=True)
-def setup_db():
-    # create / drop tables around each test to avoid leftovers
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
-
 
 @pytest.fixture
 def session_factory():
@@ -58,7 +46,6 @@ def player_profile_service(players_repo, games_repo):
 def test_player_with_no_games_has_zero_stats(player_profile_service, players_repo):
     # arrange: register player but do not insert any game
     players_repo.create(Player(player_id="p1", name="Test", is_active=True))
-
     profile = player_profile_service.get_profile("p1")
 
     assert profile.player_id == "p1"

--- a/backend/tests/integration/test_records.py
+++ b/backend/tests/integration/test_records.py
@@ -9,22 +9,10 @@ from models.enums import Corporation, MapName
 
 import pytest
 
-# database fixtures
-from db.models import Base
-from db.session import engine
-
-
 @pytest.fixture
 def players_repo(session_factory):
     from repositories.player_repository import PlayersRepository
     return PlayersRepository(session_factory=session_factory)
-
-
-@pytest.fixture(scope="function", autouse=True)
-def setup_db():
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture

--- a/backend/tests/test_game_service.py
+++ b/backend/tests/test_game_service.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import MagicMock
+from services.game_service import GamesService
+from models.player_result import PlayerResult, PlayerEndStats
+from models.player_score import PlayerScore
+from models.enums import Corporation
+
+
+def make_player(player_id: str, corp: Corporation) -> PlayerResult:
+    scores = PlayerScore(
+        terraform_rating=20,
+        milestone_points=0,
+        milestones=[],
+        award_points=0,
+        card_points=0,
+        card_resource_points=0,
+        greenery_points=0,
+        city_points=0,
+        turmoil_points=0,
+    )
+    return PlayerResult(
+        player_id=player_id,
+        corporation=corp,
+        scores=scores,
+        end_stats=PlayerEndStats(mc_total=0),
+    )
+
+
+@pytest.fixture
+def service():
+    return GamesService(
+        games_repository=MagicMock(),
+        players_repository=MagicMock(),
+    )
+
+
+class TestValidateCorporations:
+    def test_distinct_non_novel_corps_ok(self, service):
+        players = [
+            make_player("p1", Corporation.CREDICOR),
+            make_player("p2", Corporation.ECOLINE),
+        ]
+        service._validate_corporations(players)  # no exception
+
+    def test_duplicate_non_novel_raises(self, service):
+        players = [
+            make_player("p1", Corporation.CREDICOR),
+            make_player("p2", Corporation.CREDICOR),
+        ]
+        with pytest.raises(ValueError, match="more than one player"):
+            service._validate_corporations(players)
+
+    def test_two_players_with_novel_ok(self, service):
+        players = [
+            make_player("p1", Corporation.NOVEL),
+            make_player("p2", Corporation.NOVEL),
+        ]
+        service._validate_corporations(players)  # no exception
+
+    def test_novel_mixed_with_duplicate_non_novel_raises(self, service):
+        players = [
+            make_player("p1", Corporation.NOVEL),
+            make_player("p2", Corporation.CREDICOR),
+            make_player("p3", Corporation.CREDICOR),
+        ]
+        with pytest.raises(ValueError, match="more than one player"):
+            service._validate_corporations(players)

--- a/backend/tests/test_player_profile.py
+++ b/backend/tests/test_player_profile.py
@@ -8,17 +8,6 @@ from mappers.game_mapper import game_dto_to_model
 
 import pytest
 
-# database fixtures
-from db.models import Base
-from db.session import engine
-
-
-@pytest.fixture(scope="function", autouse=True)
-def setup_db():
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
-
 
 @pytest.fixture
 def session_factory():

--- a/backend/tests/test_records.py
+++ b/backend/tests/test_records.py
@@ -9,18 +9,6 @@ from models.enums import Corporation, MapName
 
 import pytest
 
-# database fixtures
-from db.models import Base
-from db.session import engine
-
-
-@pytest.fixture(scope="function", autouse=True)
-def setup_db():
-    Base.metadata.create_all(bind=engine)
-    yield
-    Base.metadata.drop_all(bind=engine)
-
-
 @pytest.fixture
 def session_factory():
     from db.session import get_session

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,27 @@
+services:
+  db_test:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: tm_user
+      POSTGRES_PASSWORD: tm_pass
+      POSTGRES_DB: tm_scorekeeper_test
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tm_user -d tm_scorekeeper_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend_test:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    volumes:
+      - ./backend:/app
+    environment:
+      DATABASE_URL: postgresql://tm_user:tm_pass@db_test:5432/tm_scorekeeper_test
+    depends_on:
+      db_test:
+        condition: service_healthy
+    entrypoint: ["sh", "-c", "alembic upgrade head && python -m pytest tests -q"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       DATABASE_URL: postgresql://tm_user:tm_pass@db:5432/tm_scorekeeper
       FRONTEND_URL: http://localhost:5173
+      SEED_DATA: "true"
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/src/components/Select/Select.module.css
+++ b/frontend/src/components/Select/Select.module.css
@@ -47,6 +47,10 @@
   cursor: not-allowed;
 }
 
+.select option:disabled {
+  color: #9ca3af;
+}
+
 .errorText {
   font-size: var(--font-size-sm);
   color: var(--color-error);

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -4,6 +4,7 @@ import styles from './Select.module.css'
 export interface SelectOption {
   value: string
   label: string
+  disabled?: boolean
 }
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
@@ -41,7 +42,7 @@ export default function Select({
       >
         {placeholder && <option value="">{placeholder}</option>}
         {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
+          <option key={opt.value} value={opt.value} disabled={opt.disabled}>
             {opt.label}
           </option>
         ))}

--- a/frontend/src/pages/GameForm/steps/StepAwards.tsx
+++ b/frontend/src/pages/GameForm/steps/StepAwards.tsx
@@ -22,7 +22,8 @@ export default function StepAwards({ state, onChange }: Props) {
 
   const awardOptions = availableAwards.map((a) => ({
     value: a,
-    label: usedAwardNames.includes(a) ? `${a} (en uso)` : a,
+    label: a,
+    disabled: usedAwardNames.includes(a),
   }))
 
   const updateAward = (index: number, patch: Partial<AwardEntry>) => {

--- a/frontend/src/pages/GameForm/steps/StepCorpsAndTR.tsx
+++ b/frontend/src/pages/GameForm/steps/StepCorpsAndTR.tsx
@@ -26,10 +26,12 @@ export default function StepCorpsAndTR({ state, onChange }: Props) {
   return (
     <div className={styles.stepContent}>
       {state.players.map((player) => {
-        const otherCorps = usedCorps.filter((c) => c !== player.corporation)
+        const otherCorps = usedCorps.filter(
+          (c) => c !== player.corporation && c !== Corporation.NOVEL,
+        )
         const corpOptions = CORP_OPTIONS.map((opt) => ({
           ...opt,
-          label: otherCorps.includes(opt.value as Corporation) ? `${opt.label} (en uso)` : opt.label,
+          disabled: otherCorps.includes(opt.value as Corporation),
         }))
 
         return (

--- a/frontend/src/pages/GameRecords/GameRecords.tsx
+++ b/frontend/src/pages/GameRecords/GameRecords.tsx
@@ -31,7 +31,6 @@ export default function GameRecords() {
         <div className={styles.header}>
           <span className={styles.icon}>🏆</span>
           <h1 className={styles.title}>¡Partida guardada!</h1>
-          <p className={styles.subtitle}>Partida #{gameId}</p>
         </div>
 
         <RecordsSection records={records} loading={loading} notAvailable={notAvailable} />

--- a/frontend/src/test/unit/validation.test.ts
+++ b/frontend/src/test/unit/validation.test.ts
@@ -2,11 +2,24 @@ import { describe, it, expect } from 'vitest'
 import {
   validateStepGameSetup,
   validateStepPlayerSelection,
+  validateStepCorpsAndTR,
   validateStepAwards,
   validateStepMilestones,
 } from '@/utils/validation'
-import { MapName, Award, Milestone } from '@/constants/enums'
-import type { AwardEntry, MilestoneEntry } from '@/pages/GameForm/GameForm.types'
+import { MapName, Award, Milestone, Corporation } from '@/constants/enums'
+import type { AwardEntry, MilestoneEntry, PlayerFormData } from '@/pages/GameForm/GameForm.types'
+
+const makePlayer = (id: string, corp: Corporation | ''): PlayerFormData => ({
+  player_id: id,
+  name: id,
+  corporation: corp,
+  terraform_rating: 20,
+  card_resource_points: 0,
+  card_points: 0,
+  greenery_points: 0,
+  city_points: 0,
+  turmoil_points: null,
+})
 
 describe('validateStepGameSetup', () => {
   it('returns no errors for valid data', () => {
@@ -40,6 +53,34 @@ describe('validateStepPlayerSelection', () => {
 
   it('rejects more than 5 players', () => {
     expect(validateStepPlayerSelection(['p1', 'p2', 'p3', 'p4', 'p5', 'p6']).length).toBeGreaterThan(0)
+  })
+})
+
+describe('validateStepCorpsAndTR', () => {
+  it('returns no errors for distinct non-NOVEL corps', () => {
+    const players = [makePlayer('p1', Corporation.CREDICOR), makePlayer('p2', Corporation.ECOLINE)]
+    expect(validateStepCorpsAndTR(players)).toHaveLength(0)
+  })
+
+  it('rejects duplicate non-NOVEL corps', () => {
+    const players = [makePlayer('p1', Corporation.CREDICOR), makePlayer('p2', Corporation.CREDICOR)]
+    const errors = validateStepCorpsAndTR(players)
+    expect(errors.some((e) => e.includes('misma corporación'))).toBe(true)
+  })
+
+  it('allows multiple players to choose NOVEL', () => {
+    const players = [makePlayer('p1', Corporation.NOVEL), makePlayer('p2', Corporation.NOVEL)]
+    expect(validateStepCorpsAndTR(players)).toHaveLength(0)
+  })
+
+  it('rejects duplicate non-NOVEL even when mixed with NOVEL', () => {
+    const players = [
+      makePlayer('p1', Corporation.NOVEL),
+      makePlayer('p2', Corporation.CREDICOR),
+      makePlayer('p3', Corporation.CREDICOR),
+    ]
+    const errors = validateStepCorpsAndTR(players)
+    expect(errors.some((e) => e.includes('misma corporación'))).toBe(true)
   })
 })
 

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,4 +1,5 @@
 import { MIN_PLAYERS, MAX_PLAYERS, MAX_MILESTONES, MAX_AWARDS } from '@/constants/gameRules'
+import { Corporation } from '@/constants/enums'
 import type { GameFormState, PlayerFormData, AwardEntry, MilestoneEntry } from '@/pages/GameForm/GameForm.types'
 
 export function validateStepGameSetup(state: Pick<GameFormState, 'date' | 'map' | 'generations'>): string[] {
@@ -19,8 +20,9 @@ export function validateStepPlayerSelection(playerIds: string[]): string[] {
 export function validateStepCorpsAndTR(players: PlayerFormData[]): string[] {
   const errors: string[] = []
   const corps = players.map((p) => p.corporation).filter(Boolean)
-  const unique = new Set(corps)
-  if (unique.size < corps.length) errors.push('Dos jugadores no pueden usar la misma corporación.')
+  const nonNovelCorps = corps.filter((c) => c !== Corporation.NOVEL)
+  const unique = new Set(nonNovelCorps)
+  if (unique.size < nonNovelCorps.length) errors.push('Dos jugadores no pueden usar la misma corporación.')
   players.forEach((p) => {
     if (!p.corporation) errors.push(`${p.name}: corporación requerida.`)
     if (p.terraform_rating < 0) errors.push(`${p.name}: TR debe ser mayor o igual a 0.`)


### PR DESCRIPTION
Fixes:

- Permite que la corporación Novel se cargue para varios jugadores
- Bloquea de los listados las opciones de corporaciones y recompensas ya seleccionadas
- Arregla el error en el que una batería de tests eliminaba la base de datos
- Automatiza la actualización de la base de datos: ahora es suficiente con hacer un `make dev` o `docker compose up` para actualizar base de datos y levantar los contenedores
- Agrega seed de datos inicial con 6 jugadores: en caso de reiniciar la base de datos, se inicia con 6 jugadores creados.