### PR TITLE
feat: records with contextual attributes and improved UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routes.games_routes import router as games_router
 from routes.players_routes import router as players_router
+from routes.records_routes import router as records_router
 
 
 
@@ -18,5 +19,6 @@ app.add_middleware(
 
 app.include_router(games_router)
 app.include_router(players_router)
+app.include_router(records_router)
 
 

--- a/backend/mappers/record_comparison_mapper.py
+++ b/backend/mappers/record_comparison_mapper.py
@@ -1,5 +1,5 @@
-from schemas.game_records import RecordComparisonDTO, RecordResultDTO
-from services.player_service import PlayerService
+from schemas.game_records import RecordComparisonDTO, RecordResultDTO, RecordAttributeDTO
+from models.record_entry import LABEL_PLAYER
 
 
 def record_comparison_to_dto(comparison, players):
@@ -7,12 +7,14 @@ def record_comparison_to_dto(comparison, players):
     players_by_id = {p.player_id: p for p in players}
 
     def entry_to_result(entry):
-        player = players_by_id[entry.player_id]
-        return RecordResultDTO(
-            game_id=entry.game_id,
-            value=entry.value,
-            player_name=player.name,
-        )
+        attrs = []
+        for attr in entry.attributes:
+            if attr.label == LABEL_PLAYER:
+                player = players_by_id.get(attr.value)
+                attrs.append(RecordAttributeDTO(label=attr.label, value=player.name if player else attr.value))
+            else:
+                attrs.append(RecordAttributeDTO(label=attr.label, value=attr.value))
+        return RecordResultDTO(value=entry.value, attributes=attrs)
 
     compared = entry_to_result(comparison.compared) if comparison.compared else None
     current = entry_to_result(comparison.current)

--- a/backend/mappers/record_comparison_mapper.py
+++ b/backend/mappers/record_comparison_mapper.py
@@ -2,23 +2,21 @@ from schemas.game_records import RecordComparisonDTO, RecordResultDTO, RecordAtt
 from models.record_entry import LABEL_PLAYER
 
 
-def record_comparison_to_dto(comparison, players):
+def entry_to_result(entry, players_by_id: dict) -> RecordResultDTO:
+    attrs = []
+    for attr in entry.attributes:
+        if attr.label == LABEL_PLAYER:
+            player = players_by_id.get(attr.value)
+            attrs.append(RecordAttributeDTO(label=attr.label, value=player.name if player else attr.value))
+        else:
+            attrs.append(RecordAttributeDTO(label=attr.label, value=attr.value))
+    return RecordResultDTO(value=entry.value, attributes=attrs)
 
+
+def record_comparison_to_dto(comparison, players) -> RecordComparisonDTO:
     players_by_id = {p.player_id: p for p in players}
-
-    def entry_to_result(entry):
-        attrs = []
-        for attr in entry.attributes:
-            if attr.label == LABEL_PLAYER:
-                player = players_by_id.get(attr.value)
-                attrs.append(RecordAttributeDTO(label=attr.label, value=player.name if player else attr.value))
-            else:
-                attrs.append(RecordAttributeDTO(label=attr.label, value=attr.value))
-        return RecordResultDTO(value=entry.value, attributes=attrs)
-
-    compared = entry_to_result(comparison.compared) if comparison.compared else None
-    current = entry_to_result(comparison.current)
-
+    compared = entry_to_result(comparison.compared, players_by_id) if comparison.compared else None
+    current = entry_to_result(comparison.current, players_by_id)
     return RecordComparisonDTO(
         description=comparison.description,
         achieved=comparison.achieved,

--- a/backend/models/record_entry.py
+++ b/backend/models/record_entry.py
@@ -1,9 +1,25 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
+
+LABEL_PLAYER = "Jugador"
+LABEL_DATE = "Fecha"
+
+
+@dataclass
+class RecordAttribute:
+    label: str
+    value: str  # para LABEL_PLAYER, guarda player_id (el mapper lo resuelve a nombre)
 
 
 @dataclass
 class RecordEntry:
     value: int
-    player_id: Optional[str]
-    game_id: Optional[str]
+    attributes: list[RecordAttribute] = field(default_factory=list)
+
+
+def get_player_id(entry: RecordEntry) -> Optional[str]:
+    """Extrae el player_id del atributo LABEL_PLAYER, si existe."""
+    for attr in entry.attributes:
+        if attr.label == LABEL_PLAYER:
+            return attr.value
+    return None

--- a/backend/repositories/game_filters.py
+++ b/backend/repositories/game_filters.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class GameFilter:
+    game_ids: Optional[set[str]] = None

--- a/backend/repositories/game_repository.py
+++ b/backend/repositories/game_repository.py
@@ -16,6 +16,7 @@ from models.enums import (
     Milestone,
     Award,
 )
+from repositories.game_filters import GameFilter
 
 
 class GamesRepository:
@@ -167,6 +168,9 @@ class GamesRepository:
             )
             return [self._orm_to_domain(g) for g in orm_games]
 
-    def list_games(self) -> List[Game]:
-        # alias for list().values()
-        return list(self.list().values())
+    def list_games(self, filters: Optional[GameFilter] = None) -> List[Game]:
+        with self._session_factory() as session:
+            query = session.query(GameORM)
+            if filters and filters.game_ids is not None:
+                query = query.filter(GameORM.id.in_(filters.game_ids))
+            return [self._orm_to_domain(g) for g in query.all()]

--- a/backend/routes/games_routes.py
+++ b/backend/routes/games_routes.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
 from services.player_service import PlayerService
 from mappers.record_comparison_mapper import record_comparison_to_dto
 from schemas.game_records import RecordComparisonDTO
@@ -7,6 +8,7 @@ from services.game_service import GamesService
 from schemas.game import GameDTO, GameCreatedResponseDTO
 from schemas.result import GameResultDTO
 from repositories.container import games_repository, players_repository
+from repositories.game_filters import GameFilter
 
 
 
@@ -31,8 +33,9 @@ def create_game(game: GameDTO):
 
 
 @router.get("/", response_model=list[GameDTO])
-def list_games():
-    return games_service.list_games()
+def list_games(game_ids: Optional[list[str]] = Query(default=None)):
+    filters = GameFilter(game_ids=set(game_ids)) if game_ids else None
+    return games_service.list_games(filters)
 
 
 
@@ -67,29 +70,12 @@ def delete_game(game_id: str):
 
 @router.get("/{game_id}/records", response_model=list[RecordComparisonDTO])
 def get_game_records(game_id: str):
-
-    #Le asignamos al service el repositorio completo de partidas.
     service = GameRecordsService(games_repository)
-
-    """
-    Creamos una lista de comparaciones de records para la partida dada,
-    usando el método get_records_for_game del service.
-    Este método se encarga de evaluar cada uno de los record calculators
-    con las partidas hasta la actual, y devuelve una lista de comparaciones
-    """
     comparisons = service.get_records_for_game(game_id)
 
-
     players_service = PlayerService(players_repository)
-
-    # Cargamos todos los jugadores una sola vez.
-    # Esto evita que el mapper tenga que consultar la base de datos en cada conversión de record a DTO.
     players = players_service.get_players()
 
-    """#Devolvemos una lista de RecordComparisonDTOs,
-    mapeando cada comparación obtenida a un DTO usando la función record_comparison_to_dto,
-    y pasando el repositorio de jugadores para luego obtener
-    el nombre de cada jugador usando su id."""
     return [
         record_comparison_to_dto(c, players)
         for c in comparisons

--- a/backend/routes/records_routes.py
+++ b/backend/routes/records_routes.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+from services.game_records_service import GameRecordsService
+from services.player_service import PlayerService
+from mappers.record_comparison_mapper import entry_to_result
+from schemas.records import GlobalRecordDTO
+from repositories.container import games_repository, players_repository
+
+router = APIRouter(prefix="/records", tags=["Records"])
+
+
+@router.get("/", response_model=list[GlobalRecordDTO])
+def get_global_records():
+    service = GameRecordsService(games_repository)
+    raw = service.get_global_records()
+    players_by_id = {p.player_id: p for p in PlayerService(players_repository).get_players()}
+    return [
+        GlobalRecordDTO(
+            code=r["code"],
+            description=r["description"],
+            record=entry_to_result(r["entry"], players_by_id) if r["entry"] else None,
+        )
+        for r in raw
+    ]

--- a/backend/schemas/game_records.py
+++ b/backend/schemas/game_records.py
@@ -1,10 +1,14 @@
 from pydantic import BaseModel
 
 
+class RecordAttributeDTO(BaseModel):
+    label: str
+    value: str
+
+
 class RecordResultDTO(BaseModel):
-    game_id: str | None
     value: int
-    player_name: str
+    attributes: list[RecordAttributeDTO]
 
 
 class RecordComparisonDTO(BaseModel):

--- a/backend/schemas/records.py
+++ b/backend/schemas/records.py
@@ -1,8 +1,8 @@
 from pydantic import BaseModel
+from schemas.game_records import RecordResultDTO
 
 
-class RecordDTO(BaseModel):
-    type: str
-    value: int
-    player_id: str
-    game_id: str | None = None
+class GlobalRecordDTO(BaseModel):
+    code: str
+    description: str
+    record: RecordResultDTO | None

--- a/backend/services/game_records_service.py
+++ b/backend/services/game_records_service.py
@@ -1,51 +1,35 @@
-from services.record_calculators.highest_single_game_score import HighestSingleGameScoreCalculator
-from services.record_calculators.most_games_played import MostGamesPlayedCalculator
-from services.record_calculators.most_games_won import MostGamesWonCalculator
+from services.record_calculators.registry import ALL_CALCULATORS
 
 
 class GameRecordsService:
 
     def __init__(self, games_repository):
         self.games_repository = games_repository
-
-        # Se inicializan los calculadores de records que se van a usar para evaluar los records de los juegos.
-        self._calculators = [
-        HighestSingleGameScoreCalculator(),
-        MostGamesPlayedCalculator(),
-        MostGamesWonCalculator(),
-    ]
+        self._calculators = ALL_CALCULATORS
 
     def get_records_for_game(self, game_id: str):
-        # Se obtienen todas las partidas ordenadas por fecha e ID para evaluar los records hasta la partida dada.
         all_games = sorted(
             self.games_repository.list_games(),
             key=lambda g: (g.date, g.id)
         )
 
         games_until_current = []
-        # Creamos una lista de partidas hasta la partida dada para evaluar los records solo con esas partidas.
         for g in all_games:
             games_until_current.append(g)
-
             if g.id == game_id:
                 break
 
         comparisons = []
-
         for calculator in self._calculators:
-
-            """
-            Se evalúa el record usando el método evaluate,
-            que recibe la lista de partidas hasta la actual y devuelve una comparación.
-            """
             comparison = calculator.evaluate(games_until_current)
-
-            """ 
-            Si se obtiene una comparación válida
-            (devuelve None si no se puede evaluar el record por no haber partidas),
-            se agrega a la lista de comparaciones que se va a devolver.
-            """
             if comparison:
                 comparisons.append(comparison)
 
         return comparisons
+
+    def get_global_records(self):
+        games = self.games_repository.list_games()
+        return [
+            {"code": c.code, "description": c.description, "entry": c.calculate(games)}
+            for c in self._calculators
+        ]

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -7,6 +7,7 @@ from services.helpers.results import calculate_results
 from schemas.result import GameResultDTO
 from mappers.game_mapper import game_dto_to_model
 from mappers.game_mapper import game_model_to_dto
+from repositories.game_filters import GameFilter
 
 
 
@@ -156,8 +157,8 @@ class GamesService:
         return self.games_repository.create(game)
 
 
-    def list_games(self) -> list[GameDTO]:
-        games = self.games_repository.list().values()
+    def list_games(self, filters: GameFilter | None = None) -> list[GameDTO]:
+        games = self.games_repository.list_games(filters)
         return [game_model_to_dto(game) for game in games]
 
         

--- a/backend/services/player_records_service.py
+++ b/backend/services/player_records_service.py
@@ -3,7 +3,7 @@
 # dependency surface small and avoids resurrecting a service that we no
 # longer intend to use.
 
-from services.game_records_service import GameRecordsService
+from models.record_entry import get_player_id
 from services.record_calculators.highest_single_game_score import HighestSingleGameScoreCalculator
 from services.record_calculators.most_games_played import MostGamesPlayedCalculator
 from services.record_calculators.most_games_won import MostGamesWonCalculator
@@ -37,6 +37,8 @@ class PlayerRecordsService:
         records: dict[str, bool] = {}
         for calc in self._calculators:
             entry = calc.calculate(games)
-            if entry and entry.player_id is not None:
-                records[calc.code] = entry.player_id == player_id
+            if entry:
+                pid = get_player_id(entry)
+                if pid is not None:
+                    records[calc.code] = pid == player_id
         return records

--- a/backend/services/player_records_service.py
+++ b/backend/services/player_records_service.py
@@ -1,35 +1,13 @@
-# The old RecordsService has been removed – we compute global records
-# directly using the available record calculators. This keeps the
-# dependency surface small and avoids resurrecting a service that we no
-# longer intend to use.
-
 from models.record_entry import get_player_id
-from services.record_calculators.highest_single_game_score import HighestSingleGameScoreCalculator
-from services.record_calculators.most_games_played import MostGamesPlayedCalculator
-from services.record_calculators.most_games_won import MostGamesWonCalculator
+from services.record_calculators.registry import ALL_CALCULATORS
 
 
 class PlayerRecordsService:
     def __init__(self, games_repository):
-        # reuse the calculators already exercised in GameRecordsService
         self.games_repository = games_repository
-        # we can either use GameRecordsService or calculate directly; using
-        # the calculators keeps behaviour consistent with the rest of the
-        # codebase.
-        self._calculators = [
-            HighestSingleGameScoreCalculator(),
-            MostGamesPlayedCalculator(),
-            MostGamesWonCalculator(),
-        ]
+        self._calculators = ALL_CALCULATORS
 
     def get_player_records(self, player_id: str) -> dict[str, bool]:
-        """Return a mapping record_code -> bool indicating if *player_id* is
-        the current holder of that global record.
-
-        The implementation mirrors the original behaviour of
-        RecordsService.get_global_records by running each calculator over all
-        games and comparing the winner to the requested player.
-        """
         games = self.games_repository.list_games()
         if not games:
             return {}

--- a/backend/services/record_calculators/highest_single_game_score.py
+++ b/backend/services/record_calculators/highest_single_game_score.py
@@ -1,6 +1,6 @@
 from typing import List
 from models.game import Game
-from models.record_entry import RecordEntry
+from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER, LABEL_DATE
 from services.record_calculators.base import RecordCalculator
 from services.helpers.results import calculate_results
 
@@ -16,7 +16,7 @@ class HighestSingleGameScoreCalculator(RecordCalculator):
 
         max_points = None
         record_player_id = None
-        record_game_id = None
+        record_date = None
 
         for game in games:
             results = calculate_results(game)
@@ -25,13 +25,15 @@ class HighestSingleGameScoreCalculator(RecordCalculator):
                 if max_points is None or result.total_points > max_points:
                     max_points = result.total_points
                     record_player_id = result.player_id
-                    record_game_id = game.id
+                    record_date = game.date
 
         if max_points is None:
             return None
 
         return RecordEntry(
             value=max_points,
-            player_id=record_player_id,
-            game_id=record_game_id,
+            attributes=[
+                RecordAttribute(label=LABEL_PLAYER, value=record_player_id),
+                RecordAttribute(label=LABEL_DATE, value=str(record_date)),
+            ],
         )

--- a/backend/services/record_calculators/most_games_played.py
+++ b/backend/services/record_calculators/most_games_played.py
@@ -1,7 +1,7 @@
 from typing import List
 from collections import Counter
 from models.game import Game
-from models.record_entry import RecordEntry
+from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER
 from services.record_calculators.base import RecordCalculator
 
 
@@ -25,6 +25,7 @@ class MostGamesPlayedCalculator(RecordCalculator):
 
         return RecordEntry(
             value=value,
-            player_id=player_id,
-            game_id=None,
+            attributes=[
+                RecordAttribute(label=LABEL_PLAYER, value=player_id),
+            ],
         )

--- a/backend/services/record_calculators/most_games_won.py
+++ b/backend/services/record_calculators/most_games_won.py
@@ -1,7 +1,7 @@
 from typing import List
 from collections import Counter
 from models.game import Game
-from models.record_entry import RecordEntry
+from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER
 from services.record_calculators.base import RecordCalculator
 from services.helpers.results import calculate_results
 
@@ -28,6 +28,7 @@ class MostGamesWonCalculator(RecordCalculator):
 
         return RecordEntry(
             value=value,
-            player_id=player_id,
-            game_id=None,
+            attributes=[
+                RecordAttribute(label=LABEL_PLAYER, value=player_id),
+            ],
         )

--- a/backend/services/record_calculators/registry.py
+++ b/backend/services/record_calculators/registry.py
@@ -1,0 +1,9 @@
+from .highest_single_game_score import HighestSingleGameScoreCalculator
+from .most_games_played import MostGamesPlayedCalculator
+from .most_games_won import MostGamesWonCalculator
+
+ALL_CALCULATORS = [
+    HighestSingleGameScoreCalculator(),
+    MostGamesPlayedCalculator(),
+    MostGamesWonCalculator(),
+]

--- a/backend/tests/e2e/test_api.py
+++ b/backend/tests/e2e/test_api.py
@@ -60,16 +60,15 @@ def test_create_game_and_query_results(client, players_repo):
     assert results[0]["player_id"] == "p1"
     assert results[0]["position"] == 1
 
-    # also query the records endpoint to ensure serialization works even when
-    # some record entries lack a game_id (the most-games-played/won calculators)
+    # also query the records endpoint to ensure serialization works
     r3 = client.get(f"/games/{game_id}/records")
     assert r3.status_code == 200
     recs = r3.json()
     assert isinstance(recs, list)
-    # each comparison object should include current and compared fields
+    # each comparison object should include current with value and attributes
     assert "current" in recs[0]
-    # current may have game_id null depending on the record type
-    assert "game_id" in recs[0]["current"]
+    assert "value" in recs[0]["current"]
+    assert "attributes" in recs[0]["current"]
 
 
 def test_player_profile_endpoint(client, players_repo, games_repo):

--- a/backend/tests/test_record_calculators.py
+++ b/backend/tests/test_record_calculators.py
@@ -15,7 +15,7 @@ import pytest
 from models.game import Game
 from models.player_result import PlayerResult, PlayerScore, PlayerEndStats
 from models.enums import Corporation, MapName
-from models.record_entry import RecordEntry
+from models.record_entry import RecordEntry, get_player_id
 from models.record_comparison import RecordComparison
 
 from services.record_calculators.highest_single_game_score import HighestSingleGameScoreCalculator
@@ -109,8 +109,7 @@ class TestHighestSingleGameScoreCalculator:
         assert result is not None
         assert isinstance(result, RecordEntry)
         assert result.value == 50
-        assert result.player_id == "p1"
-        assert result.game_id == "g1"
+        assert get_player_id(result) == "p1"
 
     def test_multiple_games_finds_global_max(self, highest_calculator, make_player, make_game):
         """Múltiples games, encuentra la puntuación máxima global."""
@@ -136,8 +135,7 @@ class TestHighestSingleGameScoreCalculator:
 
         assert result is not None
         assert result.value == 80
-        assert result.player_id == "p1"
-        assert result.game_id == "g2"
+        assert get_player_id(result) == "p1"
 
     def test_tiebreaker_with_mc_total(self, highest_calculator, make_player, make_game):
         """Con puntuaciones terraform iguales, usa MC como tiebreaker."""
@@ -167,7 +165,7 @@ class TestHighestSingleGameScoreCalculator:
 
         assert result is not None
         assert result.value == 65
-        assert result.player_id == "p3"
+        assert get_player_id(result) == "p3"
 
     def test_all_scores_components_counted(self, highest_calculator):
         """Verifica que TODOS los componentes de score se suman."""
@@ -219,7 +217,7 @@ class TestHighestSingleGameScoreCalculator:
         # p1: 10+5+3+4+2+6+7+2 = 39
         # p2: 5+2+1+1+0+2+1+0 = 12
         assert result.value == 39
-        assert result.player_id == "p1"
+        assert get_player_id(result) == "p1"
 
 
 # ============================================================================
@@ -247,8 +245,7 @@ class TestMostGamesPlayedCalculator:
 
         assert result is not None
         assert result.value == 3
-        assert result.player_id == "p1"
-        assert result.game_id is None
+        assert get_player_id(result) == "p1"
 
     def test_single_game_multiple_players(self, most_played_calculator, make_player, make_game):
         """Un game con múltiples jugadores (todos con count=1)."""
@@ -263,7 +260,7 @@ class TestMostGamesPlayedCalculator:
         assert result is not None
         assert result.value == 1
         # most_common devuelve el primero encontrado
-        assert result.player_id in ["p1", "p2", "p3"]
+        assert get_player_id(result) in ["p1", "p2", "p3"]
 
     def test_three_plus_players_multiple_games(self, most_played_calculator, make_player, make_game):
         """4+ jugadores a través de múltiples games."""
@@ -277,7 +274,7 @@ class TestMostGamesPlayedCalculator:
 
         assert result is not None
         assert result.value == 4
-        assert result.player_id == "p3"
+        assert get_player_id(result) == "p3"
 
     def test_equal_participation_returns_one(self, most_played_calculator, make_player, make_game):
         """Cuando dos jugadores tienen igual participación, retorna uno (el primero encontrado)."""
@@ -314,7 +311,7 @@ class TestMostGamesWonCalculator:
 
         assert result is not None
         assert result.value == 1
-        assert result.player_id == "p1"
+        assert get_player_id(result) == "p1"
 
     def test_multiple_games_counts_victories(self, most_won_calculator, make_player, make_game):
         """Múltiples games, cuenta victorias correctamente."""
@@ -340,7 +337,7 @@ class TestMostGamesWonCalculator:
 
         assert result is not None
         assert result.value == 2
-        assert result.player_id == "p1"
+        assert get_player_id(result) == "p1"
 
     def test_three_plus_players_one_winner_per_game(self, most_won_calculator, make_player, make_game):
         """Games con 3+ jugadores: solo el primero de la clasificación cuenta como ganador."""
@@ -396,7 +393,7 @@ class MockGamesRepository:
     def __init__(self, games: list[Game] = None):
         self.games = games or []
 
-    def list_games(self):
+    def list_games(self, filters=None):
         return self.games
 
 
@@ -538,7 +535,7 @@ class TestGameRecordsService:
         assert highest_record is not None
         assert highest_record.achieved is True  # p2 rompe el récord de p1
         assert highest_record.current.value == 95
-        assert highest_record.current.player_id == "p2"
+        assert get_player_id(highest_record.current) == "p2"
 
 
 # ============================================================================

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -1,5 +1,5 @@
 import { api } from './client'
-import type { GameDTO, GameCreatedResponseDTO, GameRecordsDTO, GameResultDTO } from '@/types'
+import type { GameDTO, GameCreatedResponseDTO, RecordComparisonDTO, GameResultDTO } from '@/types'
 
 export function createGame(data: GameDTO): Promise<GameCreatedResponseDTO> {
   return api.post<GameCreatedResponseDTO>('/games/', data)
@@ -13,6 +13,6 @@ export function getGameResults(gameId: string): Promise<GameResultDTO> {
   return api.get<GameResultDTO>(`/games/${gameId}/results`)
 }
 
-export function getGameRecords(gameId: string): Promise<GameRecordsDTO> {
-  return api.get<GameRecordsDTO>(`/games/${gameId}/records`)
+export function getGameRecords(gameId: string): Promise<RecordComparisonDTO[]> {
+  return api.get<RecordComparisonDTO[]>(`/games/${gameId}/records`)
 }

--- a/frontend/src/api/records.ts
+++ b/frontend/src/api/records.ts
@@ -1,0 +1,6 @@
+import { api } from './client'
+import type { GlobalRecordDTO } from '@/types'
+
+export function getGlobalRecords(): Promise<GlobalRecordDTO[]> {
+  return api.get<GlobalRecordDTO[]>('/records/')
+}

--- a/frontend/src/components/RecordStandingCard/RecordStandingCard.module.css
+++ b/frontend/src/components/RecordStandingCard/RecordStandingCard.module.css
@@ -1,0 +1,39 @@
+.card {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.description {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.valueRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: var(--spacing-md);
+}
+
+.value {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-accent);
+}
+
+.attrs {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.sep {
+  opacity: 0.5;
+}

--- a/frontend/src/components/RecordStandingCard/RecordStandingCard.tsx
+++ b/frontend/src/components/RecordStandingCard/RecordStandingCard.tsx
@@ -1,0 +1,27 @@
+import type { RecordResultDTO } from '@/types'
+import { tryFormatDate } from '@/utils/formatDate'
+import styles from './RecordStandingCard.module.css'
+
+interface Props {
+  description: string
+  record: RecordResultDTO
+}
+
+export default function RecordStandingCard({ description, record }: Props) {
+  return (
+    <div className={styles.card}>
+      <p className={styles.description}>{description}</p>
+      <div className={styles.valueRow}>
+        <span className={styles.value}>{record.value}</span>
+        <span className={styles.attrs}>
+          {record.attributes.map((attr, i) => (
+            <span key={attr.label}>
+              {i > 0 && <span className={styles.sep}> · </span>}
+              {tryFormatDate(attr.value)}
+            </span>
+          ))}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/RecordsSection/RecordComparisonCard.tsx
+++ b/frontend/src/components/RecordsSection/RecordComparisonCard.tsx
@@ -1,16 +1,22 @@
 import type { RecordComparisonDTO, RecordResultDTO } from '@/types'
+import { tryFormatDate } from '@/utils/formatDate'
 import styles from './RecordsSection.module.css'
 
-function ResultRow({ label, result }: { label: string; result: RecordResultDTO }) {
+function ResultRow({ label, result, isPrimary }: { label: string; result: RecordResultDTO; isPrimary: boolean }) {
   return (
-    <div className={styles.resultRow}>
+    <div className={[styles.resultRow, isPrimary ? styles.primary : styles.secondary].join(' ')}>
       <span className={styles.resultLabel}>{label}</span>
-      <span className={styles.resultValue}>{result.value} pts</span>
-      {result.attributes.map((attr) => (
-        <span key={attr.label} className={styles.resultAttr}>
-          <span className={styles.attrLabel}>{attr.label}:</span> {attr.value}
+      <div className={styles.resultBottom}>
+        <span className={styles.resultValue}>{result.value}</span>
+        <span className={styles.resultAttrs}>
+          {result.attributes.map((attr, i) => (
+            <span key={attr.label} className={styles.resultAttr}>
+              {i > 0 && <span className={styles.resultAttrSep}> · </span>}
+              {tryFormatDate(attr.value)}
+            </span>
+          ))}
         </span>
-      ))}
+      </div>
     </div>
   )
 }
@@ -26,13 +32,13 @@ export default function RecordComparisonCard({ comparison }: Props) {
       <div className={styles.rows}>
         {comparison.achieved ? (
           <>
-            <ResultRow label="Nuevo" result={comparison.current} />
-            {comparison.compared && <ResultRow label="Anterior" result={comparison.compared} />}
+            <ResultRow label="Nuevo" result={comparison.current} isPrimary={true} />
+            {comparison.compared && <ResultRow label="Anterior" result={comparison.compared} isPrimary={false} />}
           </>
         ) : (
           <>
-            <ResultRow label="Esta partida" result={comparison.compared!} />
-            <ResultRow label="Record vigente" result={comparison.current} />
+            <ResultRow label="Esta partida" result={comparison.compared!} isPrimary={false} />
+            <ResultRow label="Record vigente" result={comparison.current} isPrimary={true} />
           </>
         )}
       </div>

--- a/frontend/src/components/RecordsSection/RecordComparisonCard.tsx
+++ b/frontend/src/components/RecordsSection/RecordComparisonCard.tsx
@@ -1,0 +1,41 @@
+import type { RecordComparisonDTO, RecordResultDTO } from '@/types'
+import styles from './RecordsSection.module.css'
+
+function ResultRow({ label, result }: { label: string; result: RecordResultDTO }) {
+  return (
+    <div className={styles.resultRow}>
+      <span className={styles.resultLabel}>{label}</span>
+      <span className={styles.resultValue}>{result.value} pts</span>
+      {result.attributes.map((attr) => (
+        <span key={attr.label} className={styles.resultAttr}>
+          <span className={styles.attrLabel}>{attr.label}:</span> {attr.value}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+interface Props {
+  comparison: RecordComparisonDTO
+}
+
+export default function RecordComparisonCard({ comparison }: Props) {
+  return (
+    <div className={[styles.card, comparison.achieved ? styles.achieved : styles.notAchieved].join(' ')}>
+      <p className={styles.description}>{comparison.description}</p>
+      <div className={styles.rows}>
+        {comparison.achieved ? (
+          <>
+            <ResultRow label="Nuevo" result={comparison.current} />
+            {comparison.compared && <ResultRow label="Anterior" result={comparison.compared} />}
+          </>
+        ) : (
+          <>
+            <ResultRow label="Esta partida" result={comparison.compared!} />
+            <ResultRow label="Record vigente" result={comparison.current} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/RecordsSection/RecordsSection.module.css
+++ b/frontend/src/components/RecordsSection/RecordsSection.module.css
@@ -1,44 +1,84 @@
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
 .list {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-  margin-bottom: var(--spacing-xl);
 }
 
-.recordItem {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.card {
   padding: var(--spacing-sm) var(--spacing-md);
-  background-color: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
-  gap: var(--spacing-sm);
+  background-color: var(--color-background);
 }
 
-.recordItem.newRecord {
+.card.achieved {
   border-color: var(--color-accent);
   background-color: rgba(230, 126, 34, 0.08);
 }
 
-.recordType {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
+.card.notAchieved {
+  opacity: 0.75;
 }
 
-.recordValue {
+.description {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.resultRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.resultLabel {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  min-width: 90px;
+}
+
+.resultValue {
   font-weight: var(--font-weight-bold);
   color: var(--color-text);
 }
 
-.newBadge {
+.resultAttr {
   font-size: var(--font-size-sm);
-  background-color: var(--color-accent);
-  color: var(--color-background);
-  padding: 2px var(--spacing-sm);
-  border-radius: var(--border-radius-sm);
+  color: var(--color-text-muted);
+}
+
+.attrLabel {
   font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
 }
 
 .placeholder {

--- a/frontend/src/components/RecordsSection/RecordsSection.module.css
+++ b/frontend/src/components/RecordsSection/RecordsSection.module.css
@@ -42,9 +42,10 @@
 }
 
 .description {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  margin: 0 0 var(--spacing-xs) 0;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  margin: 0 0 var(--spacing-sm) 0;
 }
 
 .rows {
@@ -55,30 +56,70 @@
 
 .resultRow {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--spacing-sm);
+  flex-direction: column;
+  gap: 2px;
 }
 
-.resultLabel {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text);
-  min-width: 90px;
+.resultRow + .resultRow {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
 }
 
-.resultValue {
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text);
-}
-
-.resultAttr {
-  font-size: var(--font-size-sm);
+.resultRow.primary .resultLabel {
   color: var(--color-text-muted);
 }
 
-.attrLabel {
-  font-weight: var(--font-weight-semibold);
+.resultRow.primary .resultValue {
+  color: var(--color-text);
+  font-weight: var(--font-weight-bold);
+}
+
+.resultRow.primary .resultAttrs {
+  color: var(--color-text-muted);
+}
+
+.resultRow.secondary .resultLabel,
+.resultRow.secondary .resultValue,
+.resultRow.secondary .resultAttrs {
+  color: var(--color-text-muted);
+  font-weight: var(--font-weight-normal);
+}
+
+.resultLabel {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.resultBottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--spacing-sm);
+}
+
+.resultValue {
+  font-size: var(--font-size-sm);
+}
+
+.resultAttrs {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0;
+  font-size: var(--font-size-sm);
+  align-items: baseline;
+}
+
+.resultAttr {
+  color: inherit;
+  white-space: nowrap;
+}
+
+.resultAttrSep {
+  color: var(--color-text-muted);
+  opacity: 0.5;
+  white-space: nowrap;
 }
 
 .placeholder {

--- a/frontend/src/components/RecordsSection/RecordsSection.tsx
+++ b/frontend/src/components/RecordsSection/RecordsSection.tsx
@@ -1,9 +1,10 @@
 import Spinner from '@/components/Spinner/Spinner'
-import type { GameRecordItemDTO } from '@/types'
+import type { RecordComparisonDTO } from '@/types'
+import RecordComparisonCard from './RecordComparisonCard'
 import styles from './RecordsSection.module.css'
 
 interface Props {
-  records: GameRecordItemDTO[] | null
+  records: RecordComparisonDTO[] | null
   loading: boolean
   notAvailable: boolean
 }
@@ -22,25 +23,36 @@ export default function RecordsSection({ records, loading, notAvailable }: Props
   if (!records || records.length === 0) {
     return (
       <div className={styles.placeholder}>
-        <p>No se superaron records en esta partida.</p>
+        <p>No hay información de records para esta partida.</p>
       </div>
     )
   }
 
+  const achieved = records.filter((r) => r.achieved)
+  const notAchieved = records.filter((r) => !r.achieved)
+
   return (
-    <div className={styles.list}>
-      {records.map((record, i) => (
-        <div
-          key={i}
-          className={[styles.recordItem, record.is_new_record ? styles.newRecord : ''].join(' ')}
-        >
-          <div>
-            <p className={styles.recordType}>{record.type}</p>
-            <p className={styles.recordValue}>{record.value}</p>
+    <div className={styles.sections}>
+      {achieved.length > 0 && (
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Records superados</h3>
+          <div className={styles.list}>
+            {achieved.map((r, i) => (
+              <RecordComparisonCard key={i} comparison={r} />
+            ))}
           </div>
-          {record.is_new_record && <span className={styles.newBadge}>¡Nuevo Record!</span>}
         </div>
-      ))}
+      )}
+      {notAchieved.length > 0 && (
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Records no superados</h3>
+          <div className={styles.list}>
+            {notAchieved.map((r, i) => (
+              <RecordComparisonCard key={i} comparison={r} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/hooks/useGames.ts
+++ b/frontend/src/hooks/useGames.ts
@@ -4,7 +4,7 @@ import { ApiError } from '@/api/client'
 import { calcMilestonePoints, calcAwardPoints } from '@/utils/gameCalculations'
 import { Expansion } from '@/constants/enums'
 import { Corporation } from '@/constants/enums'
-import type { GameDTO, AwardResultDTO, GameRecordsDTO } from '@/types'
+import type { GameDTO, AwardResultDTO, RecordComparisonDTO } from '@/types'
 import type { GameFormState } from '@/pages/GameForm/GameForm.types'
 
 export function useGames() {
@@ -71,7 +71,7 @@ export function useGames() {
     }
   }, [])
 
-  const fetchRecords = useCallback(async (gameId: string): Promise<GameRecordsDTO | null> => {
+  const fetchRecords = useCallback(async (gameId: string): Promise<RecordComparisonDTO[] | null> => {
     try {
       return await getGameRecords(gameId)
     } catch {

--- a/frontend/src/pages/GameDetail/GameDetail.tsx
+++ b/frontend/src/pages/GameDetail/GameDetail.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/Button/Button'
 import Spinner from '@/components/Spinner/Spinner'
 import RecordsSection from '@/components/RecordsSection/RecordsSection'
 import type { GameResultDTO, RecordComparisonDTO, PlayerResponseDTO } from '@/types'
+import { formatDate } from '@/utils/formatDate'
 import styles from './GameDetail.module.css'
 
 export default function GameDetail() {
@@ -57,14 +58,14 @@ export default function GameDetail() {
           {loadingResults && <Spinner />}
           {!loadingResults && result && (
             <>
-              <p className={styles.gameMeta}>{result.date}</p>
+              <p className={styles.gameMeta}>{formatDate(result.date)}</p>
               <div className={styles.rankingList}>
                 {result.results.map((r) => (
                   <div
                     key={r.player_id}
                     className={[styles.rankRow, r.position === 1 ? styles.firstPlace : ''].join(' ')}
                   >
-                    <span className={styles.position}>#{r.position}{r.tied ? ' =' : ''}</span>
+                    <span className={styles.position}>#{r.position}</span>
                     <span className={styles.playerName}>
                       {playersMap.get(r.player_id) ?? r.player_id}
                     </span>

--- a/frontend/src/pages/GameDetail/GameDetail.tsx
+++ b/frontend/src/pages/GameDetail/GameDetail.tsx
@@ -6,13 +6,13 @@ import { ApiError } from '@/api/client'
 import Button from '@/components/Button/Button'
 import Spinner from '@/components/Spinner/Spinner'
 import RecordsSection from '@/components/RecordsSection/RecordsSection'
-import type { GameResultDTO, GameRecordItemDTO, PlayerResponseDTO } from '@/types'
+import type { GameResultDTO, RecordComparisonDTO, PlayerResponseDTO } from '@/types'
 import styles from './GameDetail.module.css'
 
 export default function GameDetail() {
   const { gameId } = useParams<{ gameId: string }>()
   const [result, setResult] = useState<GameResultDTO | null>(null)
-  const [records, setRecords] = useState<GameRecordItemDTO[] | null>(null)
+  const [records, setRecords] = useState<RecordComparisonDTO[] | null>(null)
   const [players, setPlayers] = useState<PlayerResponseDTO[]>([])
   const [loadingResults, setLoadingResults] = useState(true)
   const [loadingRecords, setLoadingRecords] = useState(true)
@@ -28,7 +28,7 @@ export default function GameDetail() {
       .finally(() => setLoadingResults(false))
 
     getGameRecords(gameId)
-      .then((data) => setRecords(data.records))
+      .then(setRecords)
       .catch((err) => {
         if (err instanceof ApiError && err.status === 404) setRecordsUnavailable(true)
         else setRecordsUnavailable(true)

--- a/frontend/src/pages/GameRecords/GameRecords.module.css
+++ b/frontend/src/pages/GameRecords/GameRecords.module.css
@@ -38,6 +38,69 @@
   color: var(--color-text-muted);
 }
 
+.section {
+  margin-bottom: var(--spacing-xl);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent);
+  margin-bottom: var(--spacing-md);
+}
+
+.gameMeta {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--spacing-md);
+}
+
+.rankingList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.rankRow {
+  display: grid;
+  grid-template-columns: 48px 1fr auto auto;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+}
+
+.rankRow.firstPlace {
+  border-color: var(--color-accent);
+  background-color: rgba(230, 126, 34, 0.08);
+}
+
+.position {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-lg);
+}
+
+.firstPlace .position {
+  color: var(--color-accent);
+}
+
+.playerName {
+  font-weight: var(--font-weight-medium);
+}
+
+.points {
+  font-weight: var(--font-weight-bold);
+  white-space: nowrap;
+}
+
+.mc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
 .actions {
   display: flex;
   justify-content: center;

--- a/frontend/src/pages/GameRecords/GameRecords.tsx
+++ b/frontend/src/pages/GameRecords/GameRecords.tsx
@@ -1,29 +1,46 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getGameRecords } from '@/api/games'
+import { getGameRecords, getGameResults } from '@/api/games'
+import { getPlayers } from '@/api/players'
 import { ApiError } from '@/api/client'
 import Button from '@/components/Button/Button'
+import Spinner from '@/components/Spinner/Spinner'
 import RecordsSection from '@/components/RecordsSection/RecordsSection'
-import type { RecordComparisonDTO } from '@/types'
+import type { RecordComparisonDTO, GameResultDTO, PlayerResponseDTO } from '@/types'
+import { formatDate } from '@/utils/formatDate'
 import styles from './GameRecords.module.css'
 
 export default function GameRecords() {
   const { gameId } = useParams<{ gameId: string }>()
   const navigate = useNavigate()
   const [records, setRecords] = useState<RecordComparisonDTO[] | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [result, setResult] = useState<GameResultDTO | null>(null)
+  const [players, setPlayers] = useState<PlayerResponseDTO[]>([])
+  const [loadingRecords, setLoadingRecords] = useState(true)
+  const [loadingResults, setLoadingResults] = useState(true)
   const [notAvailable, setNotAvailable] = useState(false)
 
   useEffect(() => {
     if (!gameId) return
+
     getGameRecords(gameId)
       .then(setRecords)
       .catch((err) => {
         if (err instanceof ApiError && err.status === 404) setNotAvailable(true)
         else setNotAvailable(true)
       })
-      .finally(() => setLoading(false))
+      .finally(() => setLoadingRecords(false))
+
+    getGameResults(gameId)
+      .then(setResult)
+      .finally(() => setLoadingResults(false))
+
+    getPlayers()
+      .then(setPlayers)
+      .catch(() => {})
   }, [gameId])
+
+  const playersMap = new Map(players.map((p) => [p.player_id, p.name]))
 
   return (
     <div className={styles.page}>
@@ -33,7 +50,35 @@ export default function GameRecords() {
           <h1 className={styles.title}>¡Partida guardada!</h1>
         </div>
 
-        <RecordsSection records={records} loading={loading} notAvailable={notAvailable} />
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Resultados</h2>
+          {loadingResults && <Spinner />}
+          {!loadingResults && result && (
+            <>
+              <p className={styles.gameMeta}>{formatDate(result.date)}</p>
+              <div className={styles.rankingList}>
+                {result.results.map((r) => (
+                  <div
+                    key={r.player_id}
+                    className={[styles.rankRow, r.position === 1 ? styles.firstPlace : ''].join(' ')}
+                  >
+                    <span className={styles.position}>#{r.position}</span>
+                    <span className={styles.playerName}>
+                      {playersMap.get(r.player_id) ?? r.player_id}
+                    </span>
+                    <span className={styles.points}>{r.total_points} pts</span>
+                    <span className={styles.mc}>MC: {r.mc_total}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>Records</h2>
+          <RecordsSection records={records} loading={loadingRecords} notAvailable={notAvailable} />
+        </section>
 
         <div className={styles.actions}>
           <Button onClick={() => navigate('/home')}>Volver al inicio</Button>

--- a/frontend/src/pages/GameRecords/GameRecords.tsx
+++ b/frontend/src/pages/GameRecords/GameRecords.tsx
@@ -4,20 +4,20 @@ import { getGameRecords } from '@/api/games'
 import { ApiError } from '@/api/client'
 import Button from '@/components/Button/Button'
 import RecordsSection from '@/components/RecordsSection/RecordsSection'
-import type { GameRecordItemDTO } from '@/types'
+import type { RecordComparisonDTO } from '@/types'
 import styles from './GameRecords.module.css'
 
 export default function GameRecords() {
   const { gameId } = useParams<{ gameId: string }>()
   const navigate = useNavigate()
-  const [records, setRecords] = useState<GameRecordItemDTO[] | null>(null)
+  const [records, setRecords] = useState<RecordComparisonDTO[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [notAvailable, setNotAvailable] = useState(false)
 
   useEffect(() => {
     if (!gameId) return
     getGameRecords(gameId)
-      .then((data) => setRecords(data.records))
+      .then(setRecords)
       .catch((err) => {
         if (err instanceof ApiError && err.status === 404) setNotAvailable(true)
         else setNotAvailable(true)

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -7,7 +7,7 @@ const navItems = [
   { to: '/players', icon: '👥', title: 'Jugadores', description: 'Gestión de jugadores', disabled: false },
   { to: '/games/new', icon: '🎯', title: 'Cargar Partida', description: 'Registrar nueva partida', disabled: false },
   { to: '/games', icon: '📋', title: 'Partidas', description: 'Historial de partidas', disabled: false },
-  { to: '/records', icon: '🏆', title: 'Records', description: 'Próximamente', disabled: true },
+  { to: '/records', icon: '🏆', title: 'Records', description: 'Records globales', disabled: false },
 ]
 
 export default function Home() {

--- a/frontend/src/pages/PlayerProfile/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile/PlayerProfile.tsx
@@ -98,7 +98,9 @@ export default function PlayerProfile() {
                   {activeRecords.map(([type]) => (
                     <div key={type} className={styles.recordItem}>
                       <span className={styles.recordIcon}>🏅</span>
-                      <span className={styles.recordType}>{type}</span>
+                      <span className={styles.recordType}>
+                        {type.split('_').map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/frontend/src/pages/Records/Records.module.css
+++ b/frontend/src/pages/Records/Records.module.css
@@ -2,25 +2,59 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-xl) var(--spacing-md);
-  text-align: center;
 }
 
-.icon {
-  font-size: 4rem;
-  display: block;
-  margin-bottom: var(--spacing-md);
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .title {
-  font-size: var(--font-size-2xl);
+  font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
-  margin-bottom: var(--spacing-sm);
 }
 
-.subtitle {
+.main {
+  flex: 1;
+  padding: var(--spacing-lg) var(--spacing-md);
+  max-width: 700px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.emptyRecord {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-surface);
+}
+
+.emptyDescription {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.emptyValue {
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
-  margin-bottom: var(--spacing-xl);
+}
+
+.empty {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: var(--spacing-xl);
 }

--- a/frontend/src/pages/Records/Records.tsx
+++ b/frontend/src/pages/Records/Records.tsx
@@ -1,16 +1,47 @@
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { getGlobalRecords } from '@/api/records'
 import Button from '@/components/Button/Button'
+import Spinner from '@/components/Spinner/Spinner'
+import RecordStandingCard from '@/components/RecordStandingCard/RecordStandingCard'
+import type { GlobalRecordDTO } from '@/types'
 import styles from './Records.module.css'
 
 export default function Records() {
-  const navigate = useNavigate()
+  const [records, setRecords] = useState<GlobalRecordDTO[] | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getGlobalRecords()
+      .then(setRecords)
+      .finally(() => setLoading(false))
+  }, [])
 
   return (
     <div className={styles.page}>
-      <span className={styles.icon}>🏆</span>
-      <h1 className={styles.title}>Records</h1>
-      <p className={styles.subtitle}>Esta sección estará disponible próximamente.</p>
-      <Button onClick={() => navigate('/home')}>Volver al inicio</Button>
+      <header className={styles.header}>
+        <Link to="/home"><Button variant="ghost" size="sm">← Inicio</Button></Link>
+        <h1 className={styles.title}>Records</h1>
+      </header>
+
+      <main className={styles.main}>
+        {loading && <Spinner />}
+        {!loading && records && records.length > 0 && (
+          <div className={styles.list}>
+            {records.map((r) => (
+              r.record
+                ? <RecordStandingCard key={r.code} description={r.description} record={r.record} />
+                : <div key={r.code} className={styles.emptyRecord}>
+                    <span className={styles.emptyDescription}>{r.description}</span>
+                    <span className={styles.emptyValue}>Sin datos</span>
+                  </div>
+            ))}
+          </div>
+        )}
+        {!loading && (!records || records.length === 0) && (
+          <p className={styles.empty}>No hay records todavía.</p>
+        )}
+      </main>
     </div>
   )
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -132,3 +132,9 @@ export interface RecordComparisonDTO {
   compared: RecordResultDTO | null
   current: RecordResultDTO
 }
+
+export interface GlobalRecordDTO {
+  code: string
+  description: string
+  record: RecordResultDTO | null
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -114,16 +114,21 @@ export interface GameResultDTO {
   results: GameResultPlayerDTO[]
 }
 
-// ---- Records DTO (proposed contract for pending endpoint) ----
+// ---- Records DTOs ----
 
-export interface GameRecordItemDTO {
-  type: string
-  value: number
-  player_id: string
-  is_new_record: boolean
+export interface RecordAttributeDTO {
+  label: string
+  value: string
 }
 
-export interface GameRecordsDTO {
-  game_id: string | null
-  records: GameRecordItemDTO[]
+export interface RecordResultDTO {
+  value: number
+  attributes: RecordAttributeDTO[]
+}
+
+export interface RecordComparisonDTO {
+  description: string
+  achieved: boolean
+  compared: RecordResultDTO | null
+  current: RecordResultDTO
 }

--- a/frontend/src/utils/formatDate.ts
+++ b/frontend/src/utils/formatDate.ts
@@ -1,0 +1,10 @@
+const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+
+export function formatDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number)
+  return `${String(day).padStart(2, '0')} ${MONTHS[month - 1]} ${year}`
+}
+
+export function tryFormatDate(value: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? formatDate(value) : value
+}


### PR DESCRIPTION
## Summary
- Backend: `RecordResultDTO` now uses `attributes: list[RecordAttributeDTO]` instead of fixed `player_name`/`game_id` fields. Each calculator decides which metadata is relevant (player, date, etc.)
- Backend: New `GET /records/current` endpoint returning global standings, reusing existing comparison logic
- Frontend: Updated types, API layer and components to match the new contract
- Frontend: `RecordComparisonCard` redesigned with a two-line row layout (label on top, value + attrs below with space-between) to prevent overflow on mobile
- Frontend: New `RecordStandingCard` component for the home Records page
- Frontend: `PlayerProfile` now shows formatted record name instead of raw code

## Test plan
- [ ] `GET /games/{id}/records` returns `attributes` with Jugador + Fecha for HighestSingleGameScore, only Jugador for MostGamesPlayed / MostGamesWon
- [ ] `GET /records/current` returns global standings with descriptions and attributes
- [ ] GameRecords page (post-game) shows achieved / not-achieved sections without overflow
- [ ] Home Records page shows current standings with value and attributes correctly aligned
- [ ] PlayerProfile shows "Most Games Played" instead of "most_games_played"