### PR TITLE
fix: cross-platform compatibility for make dev (Windows + Mac)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for files that run in Linux containers
+*.sh        text eol=lf
+Makefile    text eol=lf

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -6,7 +6,7 @@ COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 # Source code is mounted as a volume in dev (hot-reload via --reload)
 # For production builds, copy source here instead

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,8 @@
+@echo off
+if "%1"=="dev"           docker compose up --build
+if "%1"=="down"          docker compose down
+if "%1"=="migrate"       docker compose exec backend alembic upgrade head
+if "%1"=="logs"          docker compose logs -f
+if "%1"=="test-backend"  (docker compose -f docker-compose.test.yml down && docker compose -f docker-compose.test.yml run --rm --build backend_test && docker compose -f docker-compose.test.yml down)
+if "%1"=="test-frontend" docker compose exec frontend npm test -- --run
+if "%1"=="typechecks"    docker compose exec frontend npm run typecheck


### PR DESCRIPTION
## Contexto

`make dev` fallaba en Windows por dos razones independientes:
1. `make` no está disponible nativamente en Windows (CMD/PowerShell)
2. `entrypoint.sh` podía tener line endings CRLF al clonar en Windows, rompiendo el contenedor Linux con el error `bad interpreter: No such file or directory`

## Cambios

### `Dockerfile.backend` — Fix CRLF (crítico)
Se agrega conversión de line endings antes del `chmod`, protegiendo contra clones con CRLF en Windows:
```dockerfile
RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
```

### `.gitattributes` — Nuevo archivo
Fuerza LF a nivel de git para archivos `.sh` y `Makefile`, previniendo el problema CRLF en futuros clones desde Windows.

### `make.bat` — Nuevo archivo para Windows
Replica exactamente los mismos targets del `Makefile` para usuarios que no tienen `make` en Windows (CMD).

## Cómo usar en cada OS

| OS | Comando |
|---|---|
| Mac / Linux | `make dev` |
| Windows (CMD) | `make.bat dev` |
| Windows (WSL) | `make dev` (sin cambios) |

### Targets disponibles en `make.bat`
```
make.bat dev            # Levanta todos los servicios
make.bat down           # Baja los servicios
make.bat migrate        # Corre migraciones
make.bat logs           # Sigue los logs
make.bat test-backend   # Corre tests del backend
make.bat test-frontend  # Corre tests del frontend
make.bat typechecks     # Corre type checks del frontend
```

## Test plan
- [ ] Mac: `make dev` sigue funcionando sin cambios
- [ ] Windows (Docker Desktop): `make.bat dev` levanta los contenedores correctamente
- [ ] Verificar que el backend no lanza error `bad interpreter` al iniciar
- [ ] Clonar en Windows y ejecutar `git ls-files --eol backend/entrypoint.sh` → debe mostrar `lf` en el índice