### PR TITLE
Add new records

### DIFF
--- a/backend/mappers/record_comparison_mapper.py
+++ b/backend/mappers/record_comparison_mapper.py
@@ -3,14 +3,31 @@ from models.record_entry import LABEL_PLAYER
 
 
 def entry_to_result(entry, players_by_id: dict) -> RecordResultDTO:
+
+    player_names = []
     attrs = []
+
     for attr in entry.attributes:
         if attr.label == LABEL_PLAYER:
             player = players_by_id.get(attr.value)
-            attrs.append(RecordAttributeDTO(label=attr.label, value=player.name if player else attr.value))
+            player_names.append(player.name if player else attr.value)
         else:
-            attrs.append(RecordAttributeDTO(label=attr.label, value=attr.value))
-    return RecordResultDTO(value=entry.value, attributes=attrs)
+            attrs.append(
+                RecordAttributeDTO(label=attr.label, value=attr.value)
+            )
+
+    if player_names:
+        attrs.append(
+            RecordAttributeDTO(
+                label=LABEL_PLAYER,
+                value=", ".join(player_names)
+            )
+        )
+
+    return RecordResultDTO(
+        value=entry.value,
+        attributes=attrs
+    )
 
 
 def record_comparison_to_dto(comparison, players) -> RecordComparisonDTO:

--- a/backend/services/helpers/records.py
+++ b/backend/services/helpers/records.py
@@ -1,0 +1,17 @@
+def max_counter_entries(counter):
+    """
+    Devuelve (max_value, keys) donde keys son todas las claves que
+    tienen el valor máximo.
+    """
+    if not counter:
+        return None, []
+
+    max_value = max(counter.values())
+
+    keys = [
+        key
+        for key, value in counter.items()
+        if value == max_value
+    ]
+
+    return max_value, keys

--- a/backend/services/record_calculators/base.py
+++ b/backend/services/record_calculators/base.py
@@ -13,24 +13,31 @@ class RecordCalculator(ABC):
     @abstractmethod
     def calculate(self, games: List[Game]) -> RecordEntry | None:
         pass
+
+    def games_for_current(self, games_until_current: List[Game]) -> List[Game]:
+        """
+        Define qué partidas usar para evaluar el resultado actual del record.
+        Por defecto usa solo la última partida.
+        Los calculators acumulativos pueden sobrescribir este método.
+        """
+        return [games_until_current[-1]]
     
     def evaluate(self, games_until_current: List[Game]) -> RecordComparison | None:
 
         if not games_until_current:
             return None
 
-        current_game = games_until_current[-1]
         previous_games = games_until_current[:-1]
 
         record_before = self.calculate(previous_games)
-        record_last_game = self.calculate([current_game])
+        record_after = self.calculate(self.games_for_current(games_until_current))
 
-        achieved = record_before is None or record_last_game.value > record_before.value
+        achieved = record_before is None or record_after.value > record_before.value
 
         return RecordComparison(
             code=self.code,
             description=self.description,
             achieved=achieved,
-            current = record_last_game if achieved else record_before,
-            compared = record_before if achieved else record_last_game,
+            current=record_after if achieved else record_before,
+            compared=record_before if achieved else record_after,
         )

--- a/backend/services/record_calculators/highest_card_points.py
+++ b/backend/services/record_calculators/highest_card_points.py
@@ -1,0 +1,8 @@
+from services.record_calculators.max_score_field import MaxScoreFieldCalculator
+
+
+HighestCardPointsCalculator = MaxScoreFieldCalculator(
+    field="card_points",
+    code="highest_card_points",
+    description="Mayor puntaje de cartas en una partida"
+)

--- a/backend/services/record_calculators/highest_card_resource_points.py
+++ b/backend/services/record_calculators/highest_card_resource_points.py
@@ -1,0 +1,8 @@
+from services.record_calculators.max_score_field import MaxScoreFieldCalculator
+
+
+HighestCardResourcePointsCalculator = MaxScoreFieldCalculator(
+    field="card_resource_points",
+    code="highest_card_resource_points",
+    description="Mayor puntaje de recursos de carta en una partida"
+)

--- a/backend/services/record_calculators/highest_single_game_score.py
+++ b/backend/services/record_calculators/highest_single_game_score.py
@@ -8,7 +8,7 @@ from services.helpers.results import calculate_results
 class HighestSingleGameScoreCalculator(RecordCalculator):
 
     code = "highest_single_game_score"
-    description = "Highest single game score"
+    description = "Mayor puntuación en una sola partida"
 
     def calculate(self, games: List[Game]) -> RecordEntry | None:
         if not games:

--- a/backend/services/record_calculators/highest_terraform_rating.py
+++ b/backend/services/record_calculators/highest_terraform_rating.py
@@ -1,0 +1,40 @@
+from typing import List
+from models.game import Game
+from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER, LABEL_DATE
+from services.record_calculators.base import RecordCalculator
+
+
+class HighestTerraformRatingCalculator(RecordCalculator):
+
+    code = "highest_terraform_rating"
+    description = "Mayor Terraform Rating en una partida"
+
+    def calculate(self, games: List[Game]) -> RecordEntry | None:
+
+        if not games:
+            return None
+
+        max_tr = None
+        record_player_id = None
+        record_date = None
+
+        for game in games:
+            for p in game.player_results:
+
+                tr = p.scores.terraform_rating
+
+                if max_tr is None or tr > max_tr:
+                    max_tr = tr
+                    record_player_id = p.player_id
+                    record_date = game.date
+
+        if max_tr is None:
+            return None
+
+        return RecordEntry(
+            value=max_tr,
+            attributes=[
+                RecordAttribute(label=LABEL_PLAYER, value=record_player_id),
+                RecordAttribute(label=LABEL_DATE, value=str(record_date)),
+            ],
+        )

--- a/backend/services/record_calculators/highest_terraform_rating.py
+++ b/backend/services/record_calculators/highest_terraform_rating.py
@@ -1,40 +1,7 @@
-from typing import List
-from models.game import Game
-from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER, LABEL_DATE
-from services.record_calculators.base import RecordCalculator
+from services.record_calculators.max_score_field import MaxScoreFieldCalculator
 
-
-class HighestTerraformRatingCalculator(RecordCalculator):
-
-    code = "highest_terraform_rating"
-    description = "Mayor Terraform Rating en una partida"
-
-    def calculate(self, games: List[Game]) -> RecordEntry | None:
-
-        if not games:
-            return None
-
-        max_tr = None
-        record_player_id = None
-        record_date = None
-
-        for game in games:
-            for p in game.player_results:
-
-                tr = p.scores.terraform_rating
-
-                if max_tr is None or tr > max_tr:
-                    max_tr = tr
-                    record_player_id = p.player_id
-                    record_date = game.date
-
-        if max_tr is None:
-            return None
-
-        return RecordEntry(
-            value=max_tr,
-            attributes=[
-                RecordAttribute(label=LABEL_PLAYER, value=record_player_id),
-                RecordAttribute(label=LABEL_DATE, value=str(record_date)),
-            ],
-        )
+HighestTerraformRatingCalculator = MaxScoreFieldCalculator(
+    field="terraform_rating",
+    code="highest_terraform_rating",
+    description="Mayor Terraform Rating en una partida"
+)

--- a/backend/services/record_calculators/max_score_field.py
+++ b/backend/services/record_calculators/max_score_field.py
@@ -1,0 +1,42 @@
+from typing import List
+from models.game import Game
+from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER, LABEL_DATE
+from services.record_calculators.base import RecordCalculator
+
+
+class MaxScoreFieldCalculator(RecordCalculator):
+
+    def __init__(self, field: str, code: str, description: str):
+        self.field = field
+        self.code = code
+        self.description = description
+
+    def calculate(self, games: List[Game]) -> RecordEntry | None:
+
+        if not games:
+            return None
+
+        max_value = None
+        record_player_id = None
+        record_date = None
+
+        for game in games:
+            for p in game.player_results:
+
+                value = getattr(p.scores, self.field)
+
+                if max_value is None or value > max_value:
+                    max_value = value
+                    record_player_id = p.player_id
+                    record_date = game.date
+
+        if max_value is None:
+            return None
+
+        return RecordEntry(
+            value=max_value,
+            attributes=[
+                RecordAttribute(label=LABEL_PLAYER, value=record_player_id),
+                RecordAttribute(label=LABEL_DATE, value=str(record_date)),
+            ],
+        )

--- a/backend/services/record_calculators/most_games_played.py
+++ b/backend/services/record_calculators/most_games_played.py
@@ -8,7 +8,7 @@ from services.record_calculators.base import RecordCalculator
 class MostGamesPlayedCalculator(RecordCalculator):
 
     code = "most_games_played"
-    description = "Most games played"
+    description = "Más partidas jugadas"
 
     def calculate(self, games: List[Game]) -> RecordEntry | None:
 

--- a/backend/services/record_calculators/most_games_played.py
+++ b/backend/services/record_calculators/most_games_played.py
@@ -1,5 +1,6 @@
 from typing import List
 from collections import Counter
+from services.helpers.records import max_counter_entries
 from models.game import Game
 from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER
 from services.record_calculators.base import RecordCalculator
@@ -9,6 +10,9 @@ class MostGamesPlayedCalculator(RecordCalculator):
 
     code = "most_games_played"
     description = "Más partidas jugadas"
+
+    def games_for_current(self, games_until_current):
+        return games_until_current
 
     def calculate(self, games: List[Game]) -> RecordEntry | None:
 
@@ -21,11 +25,12 @@ class MostGamesPlayedCalculator(RecordCalculator):
             for pr in game.player_results:
                 counter[pr.player_id] += 1
 
-        player_id, value = counter.most_common(1)[0]
+        max_games, players_with_record = max_counter_entries(counter)
 
         return RecordEntry(
-            value=value,
+            value=max_games,
             attributes=[
-                RecordAttribute(label=LABEL_PLAYER, value=player_id),
+                RecordAttribute(label=LABEL_PLAYER, value=p)
+                for p in players_with_record
             ],
         )

--- a/backend/services/record_calculators/most_games_won.py
+++ b/backend/services/record_calculators/most_games_won.py
@@ -9,7 +9,7 @@ from services.helpers.results import calculate_results
 class MostGamesWonCalculator(RecordCalculator):
 
     code = "most_games_won"
-    description = "Most games won"
+    description = "Más partidas ganadas"
 
     def calculate(self, games: List[Game]) -> RecordEntry | None:
 

--- a/backend/services/record_calculators/most_games_won.py
+++ b/backend/services/record_calculators/most_games_won.py
@@ -1,5 +1,6 @@
 from typing import List
 from collections import Counter
+from services.helpers.records import max_counter_entries
 from models.game import Game
 from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER
 from services.record_calculators.base import RecordCalculator
@@ -10,6 +11,9 @@ class MostGamesWonCalculator(RecordCalculator):
 
     code = "most_games_won"
     description = "Más partidas ganadas"
+
+    def games_for_current(self, games_until_current):
+        return games_until_current
 
     def calculate(self, games: List[Game]) -> RecordEntry | None:
 
@@ -24,11 +28,15 @@ class MostGamesWonCalculator(RecordCalculator):
             winner = results.results[0]
             wins[winner.player_id] += 1
 
-        player_id, value = wins.most_common(1)[0]
+        max_wins, players_with_record = max_counter_entries(wins)
+
+        if max_wins is None:
+            return None
 
         return RecordEntry(
-            value=value,
+            value=max_wins,
             attributes=[
-                RecordAttribute(label=LABEL_PLAYER, value=player_id),
+                RecordAttribute(label=LABEL_PLAYER, value=p)
+                for p in players_with_record
             ],
         )

--- a/backend/services/record_calculators/registry.py
+++ b/backend/services/record_calculators/registry.py
@@ -1,3 +1,5 @@
+from .highest_card_points import HighestCardPointsCalculator
+from .highest_card_resource_points import HighestCardResourcePointsCalculator
 from .highest_terraform_rating import HighestTerraformRatingCalculator
 from .highest_single_game_score import HighestSingleGameScoreCalculator
 from .most_games_played import MostGamesPlayedCalculator
@@ -7,5 +9,7 @@ ALL_CALCULATORS = [
     HighestSingleGameScoreCalculator(),
     MostGamesPlayedCalculator(),
     MostGamesWonCalculator(),
-    HighestTerraformRatingCalculator()
+    HighestTerraformRatingCalculator,
+    HighestCardPointsCalculator,
+    HighestCardResourcePointsCalculator
 ]

--- a/backend/services/record_calculators/registry.py
+++ b/backend/services/record_calculators/registry.py
@@ -1,3 +1,4 @@
+from .highest_terraform_rating import HighestTerraformRatingCalculator
 from .highest_single_game_score import HighestSingleGameScoreCalculator
 from .most_games_played import MostGamesPlayedCalculator
 from .most_games_won import MostGamesWonCalculator
@@ -6,4 +7,5 @@ ALL_CALCULATORS = [
     HighestSingleGameScoreCalculator(),
     MostGamesPlayedCalculator(),
     MostGamesWonCalculator(),
+    HighestTerraformRatingCalculator()
 ]

--- a/backend/tests/test_record_calculators.py
+++ b/backend/tests/test_record_calculators.py
@@ -611,7 +611,8 @@ class TestRecordEvaluate:
 
         assert result is not None
         assert result.code == "most_games_played"
-        assert result.description == "Most games played"
+        # description should match the calculator's own text (may be localized)
+        assert result.description == most_played_calculator.description
         assert result.achieved in [True, False]
         assert result.current is not None
         assert result.compared is not None

--- a/backend/tests/test_record_calculators.py
+++ b/backend/tests/test_record_calculators.py
@@ -409,8 +409,8 @@ class TestGameRecordsService:
 
         assert result == []
 
-    def test_single_game_returns_three_comparisons(self, make_player, make_game):
-        """Un game genera 3 comparaciones (uno por cada calculador)."""
+    def test_single_game_returns_six_comparisons(self, make_player, make_game):
+        """Un game genera 6 comparaciones (uno por cada calculador)."""
         game = make_game("g1", date(2026, 1, 1), [
             make_player("p1", terraform_rating=80),
             make_player("p2", terraform_rating=60),
@@ -420,11 +420,18 @@ class TestGameRecordsService:
 
         result = service.get_records_for_game("g1")
 
-        assert len(result) == 3
+        assert len(result) == 6
         assert all(isinstance(r, RecordComparison) for r in result)
 
         codes = {r.code for r in result}
-        assert codes == {"highest_single_game_score", "most_games_played", "most_games_won"}
+        assert codes == {
+            "highest_single_game_score",
+            "most_games_played",
+            "most_games_won",
+            "highest_terraform_rating",
+            "highest_card_points",
+            "highest_card_resource_points",
+        }
 
     def test_chronological_order_respected(self, make_player, make_game):
         """Los games se procesan en orden cronológico (date, id)."""
@@ -526,7 +533,7 @@ class TestGameRecordsService:
 
         result_g3 = service.get_records_for_game("g3")
 
-        assert len(result_g3) == 3
+        assert len(result_g3) == 6
 
         highest_record = next(
             (r for r in result_g3 if r.code == "highest_single_game_score"),


### PR DESCRIPTION
Summary

This PR refactors the record calculation system and adds three new single-game records:

Highest Terraform Rating

Highest card points

Highest card resource points

It also introduces a reusable mechanism for defining score-based records and improves the way calculators distinguish between cumulative records and single-game records.

Motivation

While implementing new records, it became clear that several calculators followed the same pattern: iterate over games and player results to find the maximum value of a specific score field.

Additionally, the original evaluation logic assumed that records were always tied to a single game, which caused incorrect behavior for cumulative records such as:

Most games played

Most games won

This PR introduces a small architectural change to address both issues.

Main changes
1. Distinguish cumulative vs single-game records

The RecordCalculator base class now allows calculators to control which games should be used when evaluating the current record.

This enables two types of records:

Single-game records

Examples:

Highest single game score

Highest Terraform Rating

Highest card points

These evaluate only the current game.

Cumulative records

Examples:

Most games played

Most games won

These evaluate all games up to the current one.

This prevents incorrect comparisons when evaluating cumulative statistics.

2. Introduce a reusable score-field calculator

A new reusable calculator (MaxScoreFieldCalculator) was introduced to simplify records that compute the maximum value of a score field.

Example:

HighestTerraformRatingCalculator = MaxScoreFieldCalculator(
    field="terraform_rating",
    code="highest_terraform_rating",
    description="Mayor Terraform Rating en una partida"
)

This avoids duplicating the same iteration logic across multiple calculators and makes adding new score-based records trivial.

3. Add new records

Three new records were added:

highest_terraform_rating

highest_card_points

highest_card_resource_points

All of them use the new reusable calculator.

Benefits

Simplifies the addition of new score-based records

Reduces duplicated logic across calculators

Correctly supports cumulative statistics

Makes the record system easier to extend

Future improvements

This refactor makes it straightforward to add additional records such as:

Highest greenery points

Highest city points

Highest milestone points

Largest victory margin