### PR TITLE
feat: add 6 new achievements

### DIFF
--- a/backend/services/achievement_evaluators/definitions.py
+++ b/backend/services/achievement_evaluators/definitions.py
@@ -77,6 +77,78 @@ GREENERY_TILES = AchievementDefinition(
     show_progress=True,
 )
 
+MILESTONE_MASTER = AchievementDefinition(
+    code="milestone_master",
+    description="Ganar una partida habiendo reclamado los 3 hitos",
+    icon=None,
+    fallback_icon="star",
+    tiers=[
+        AchievementTier(level=1, threshold=1, title="Maestro de Hitos"),
+    ],
+    show_progress=False,
+)
+
+NO_MILESTONE_WIN = AchievementDefinition(
+    code="no_milestone_win",
+    description="Ganar una partida sin haber reclamado ningún hito",
+    icon=None,
+    fallback_icon="zap",
+    tiers=[
+        AchievementTier(level=1, threshold=1, title="Lobo Solitario"),
+    ],
+    show_progress=False,
+)
+
+AWARD_MASTER = AchievementDefinition(
+    code="award_master",
+    description="Ganar una partida habiendo quedado primero en las 3 recompensas",
+    icon=None,
+    fallback_icon="trophy",
+    tiers=[
+        AchievementTier(level=1, threshold=1, title="Rey de las Recompensas"),
+    ],
+    show_progress=False,
+)
+
+NO_AWARD_WIN = AchievementDefinition(
+    code="no_award_win",
+    description="Ganar una partida sin haber quedado primero en ninguna recompensa",
+    icon=None,
+    fallback_icon="zap",
+    tiers=[
+        AchievementTier(level=1, threshold=1, title="Incomprendido"),
+    ],
+    show_progress=False,
+)
+
+STOLEN_AWARDS = AchievementDefinition(
+    code="stolen_awards",
+    description="Robar recompensas (quedar 1ro en solitario en una recompensa que no abriste)",
+    icon=None,
+    fallback_icon="shield",
+    tiers=[
+        AchievementTier(level=1, threshold=1, title="Oportunista"),
+        AchievementTier(level=2, threshold=2, title="Ladrón"),
+        AchievementTier(level=3, threshold=3, title="Gran Estafador"),
+    ],
+    show_progress=False,
+)
+
+CARD_POINTS = AchievementDefinition(
+    code="card_points",
+    description="Alcanzar X puntos de cartas en una partida",
+    icon=None,
+    fallback_icon="layers",
+    tiers=[
+        AchievementTier(level=1, threshold=10, title="Apostador"),
+        AchievementTier(level=2, threshold=20, title="Inversor"),
+        AchievementTier(level=3, threshold=30, title="Magnate"),
+        AchievementTier(level=4, threshold=40, title="Cerebro Corporativo"),
+        AchievementTier(level=5, threshold=50, title="Elon Musk"),
+    ],
+    show_progress=False,
+)
+
 ALL_MAPS = AchievementDefinition(
     code="all_maps",
     description="Jugar en distintos mapas de Marte",

--- a/backend/services/achievement_evaluators/registry.py
+++ b/backend/services/achievement_evaluators/registry.py
@@ -2,7 +2,11 @@ from services.achievement_evaluators.single_game_threshold import SingleGameThre
 from services.achievement_evaluators.accumulated import AccumulatedEvaluator
 from services.achievement_evaluators.win_streak import WinStreakEvaluator
 from services.achievement_evaluators.all_maps import AllMapsEvaluator
-from services.achievement_evaluators.definitions import HIGH_SCORE, GAMES_PLAYED, GAMES_WON, WIN_STREAK, GREENERY_TILES, ALL_MAPS
+from services.achievement_evaluators.definitions import (
+    HIGH_SCORE, GAMES_PLAYED, GAMES_WON, WIN_STREAK, GREENERY_TILES, ALL_MAPS,
+    MILESTONE_MASTER, NO_MILESTONE_WIN, AWARD_MASTER, NO_AWARD_WIN, STOLEN_AWARDS,
+    CARD_POINTS,
+)
 from services.helpers.results import calculate_results
 
 
@@ -34,6 +38,62 @@ def _high_score_extractor(player_id, game, game_result):
     return 0
 
 
+def _milestone_master_extractor(player_id, game, game_result):
+    """Return 1 if player won the game AND claimed all 3 milestones."""
+    for pr in game.player_results:
+        if pr.player_id == player_id and len(pr.scores.milestones) == 3:
+            if game_result.results and game_result.results[0].player_id == player_id and not game_result.results[0].tied:
+                return 1
+    return 0
+
+
+def _no_milestone_win_extractor(player_id, game, game_result):
+    """Return 1 if player finished 1st (including ties) with 0 milestones claimed."""
+    for pr in game.player_results:
+        if pr.player_id == player_id and len(pr.scores.milestones) == 0:
+            for r in game_result.results:
+                if r.player_id == player_id and r.position == 1:
+                    return 1
+    return 0
+
+
+def _award_master_extractor(player_id, game, game_result):
+    """Return 1 if player finished 1st (including ties) and is in first_place of all 3 awards."""
+    if len(game.awards) != 3:
+        return 0
+    for r in game_result.results:
+        if r.player_id == player_id and r.position == 1:
+            if all(player_id in a.first_place for a in game.awards):
+                return 1
+    return 0
+
+
+def _no_award_win_extractor(player_id, game, game_result):
+    """Return 1 if player finished 1st (including ties) and is not in first_place of any award."""
+    for r in game_result.results:
+        if r.player_id == player_id and r.position == 1:
+            if not any(player_id in a.first_place for a in game.awards):
+                return 1
+    return 0
+
+
+def _stolen_awards_extractor(player_id, game, game_result):
+    """Count awards where player is the sole first place AND didn't open the award."""
+    stolen = 0
+    for a in game.awards:
+        if a.first_place == [player_id] and a.opened_by != player_id:
+            stolen += 1
+    return stolen
+
+
+def _card_points_extractor(player_id, game, game_result):
+    """Extract card_points for player from game."""
+    for pr in game.player_results:
+        if pr.player_id == player_id:
+            return pr.scores.card_points
+    return 0
+
+
 def _count_greenery_tiles(player_id, games):
     """Sum greenery_points across all games for player."""
     total = 0
@@ -51,4 +111,10 @@ ALL_EVALUATORS = [
     WinStreakEvaluator(WIN_STREAK),
     AccumulatedEvaluator(GREENERY_TILES, counter=_count_greenery_tiles),
     AllMapsEvaluator(ALL_MAPS),
+    SingleGameThresholdEvaluator(MILESTONE_MASTER, extractor=_milestone_master_extractor),
+    SingleGameThresholdEvaluator(NO_MILESTONE_WIN, extractor=_no_milestone_win_extractor),
+    SingleGameThresholdEvaluator(AWARD_MASTER, extractor=_award_master_extractor),
+    SingleGameThresholdEvaluator(NO_AWARD_WIN, extractor=_no_award_win_extractor),
+    SingleGameThresholdEvaluator(STOLEN_AWARDS, extractor=_stolen_awards_extractor),
+    SingleGameThresholdEvaluator(CARD_POINTS, extractor=_card_points_extractor),
 ]

--- a/backend/tests/integration/test_achievements_routes.py
+++ b/backend/tests/integration/test_achievements_routes.py
@@ -107,8 +107,8 @@ def test_get_player_achievements(client, players_repo):
     assert response.status_code == 200
     data = response.json()
     assert "achievements" in data
-    # All 6 evaluators from ALL_EVALUATORS should appear (locked or unlocked)
-    assert len(data["achievements"]) == 6
+    # All 7 evaluators from ALL_EVALUATORS should appear (locked or unlocked)
+    assert len(data["achievements"]) == 12
     for item in data["achievements"]:
         assert "code" in item
         assert "title" in item
@@ -122,7 +122,7 @@ def test_get_catalog(client):
     assert response.status_code == 200
     data = response.json()
     assert "achievements" in data
-    assert len(data["achievements"]) == 6
+    assert len(data["achievements"]) == 12
 
 
 def test_catalog_has_tiers_and_holders(client):

--- a/backend/tests/test_achievement_evaluators.py
+++ b/backend/tests/test_achievement_evaluators.py
@@ -243,7 +243,11 @@ class TestAccumulatedEvaluator:
 
 from services.achievement_evaluators.win_streak import WinStreakEvaluator
 from services.achievement_evaluators.all_maps import AllMapsEvaluator
-from services.achievement_evaluators.registry import ALL_EVALUATORS
+from services.achievement_evaluators.registry import (
+    ALL_EVALUATORS, _milestone_master_extractor, _no_milestone_win_extractor,
+    _award_master_extractor, _no_award_win_extractor, _stolen_awards_extractor,
+    _card_points_extractor,
+)
 from models.enums import MapName
 
 
@@ -381,9 +385,348 @@ class TestAllMapsEvaluator:
         assert progress.target == 3  # next tier threshold
 
 
+# ── Milestone Master (SingleGameThreshold) Tests ─────────────────────────────
+
+class TestMilestoneMaster:
+    def _make_game_with_milestones(self, player_id, milestones, total_points, opponent_points=20):
+        """Create a game where player has specific milestones and points."""
+        from models.enums import Milestone
+        player_score = PlayerScore(
+            terraform_rating=total_points,
+            milestone_points=len(milestones) * 5,
+            milestones=[Milestone(m) for m in milestones],
+            award_points=0,
+            card_points=0,
+            card_resource_points=0,
+            greenery_points=0,
+            city_points=0,
+            turmoil_points=None,
+        )
+        opponent_score = make_player_score(terraform_rating=opponent_points)
+        return Game(
+            game_id="g1",
+            date=date(2026, 1, 1),
+            map_name=MapName.THARSIS,
+            expansions=[],
+            draft=False,
+            generations=10,
+            player_results=[
+                PlayerResult(player_id=player_id, corporation=Corporation.CREDICOR,
+                             scores=player_score, end_stats=PlayerEndStats(mc_total=30)),
+                PlayerResult(player_id="opponent", corporation=Corporation.CREDICOR,
+                             scores=opponent_score, end_stats=PlayerEndStats(mc_total=30)),
+            ],
+            awards=[],
+        )
+
+    def test_win_with_3_milestones_unlocks(self):
+        from services.achievement_evaluators.definitions import MILESTONE_MASTER
+        ev = SingleGameThresholdEvaluator(MILESTONE_MASTER, extractor=_milestone_master_extractor)
+        game = self._make_game_with_milestones("p1", ["Terraformer", "Mayor", "Gardener"], total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_win_with_2_milestones_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import MILESTONE_MASTER
+        ev = SingleGameThresholdEvaluator(MILESTONE_MASTER, extractor=_milestone_master_extractor)
+        game = self._make_game_with_milestones("p1", ["Terraformer", "Mayor"], total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_lose_with_3_milestones_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import MILESTONE_MASTER
+        ev = SingleGameThresholdEvaluator(MILESTONE_MASTER, extractor=_milestone_master_extractor)
+        game = self._make_game_with_milestones("p1", ["Terraformer", "Mayor", "Gardener"], total_points=50, opponent_points=80)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_no_milestones_win_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import MILESTONE_MASTER
+        ev = SingleGameThresholdEvaluator(MILESTONE_MASTER, extractor=_milestone_master_extractor)
+        game = self._make_game_with_milestones("p1", [], total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+
+# ── No Milestone Win (SingleGameThreshold) Tests ─────────────────────────────
+
+class TestNoMilestoneWin:
+    def _make_game_with_milestones(self, player_id, milestones, total_points, opponent_points=20, opponent_mc=30):
+        """Create a game where player has specific milestones and points."""
+        from models.enums import Milestone
+        player_score = PlayerScore(
+            terraform_rating=total_points,
+            milestone_points=len(milestones) * 5,
+            milestones=[Milestone(m) for m in milestones],
+            award_points=0,
+            card_points=0,
+            card_resource_points=0,
+            greenery_points=0,
+            city_points=0,
+            turmoil_points=None,
+        )
+        opponent_score = make_player_score(terraform_rating=opponent_points)
+        return Game(
+            game_id="g1",
+            date=date(2026, 1, 1),
+            map_name=MapName.THARSIS,
+            expansions=[],
+            draft=False,
+            generations=10,
+            player_results=[
+                PlayerResult(player_id=player_id, corporation=Corporation.CREDICOR,
+                             scores=player_score, end_stats=PlayerEndStats(mc_total=30)),
+                PlayerResult(player_id="opponent", corporation=Corporation.CREDICOR,
+                             scores=opponent_score, end_stats=PlayerEndStats(mc_total=opponent_mc)),
+            ],
+            awards=[],
+        )
+
+    def test_win_with_0_milestones_unlocks(self):
+        from services.achievement_evaluators.definitions import NO_MILESTONE_WIN
+        ev = SingleGameThresholdEvaluator(NO_MILESTONE_WIN, extractor=_no_milestone_win_extractor)
+        game = self._make_game_with_milestones("p1", [], total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_win_with_1_milestone_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import NO_MILESTONE_WIN
+        ev = SingleGameThresholdEvaluator(NO_MILESTONE_WIN, extractor=_no_milestone_win_extractor)
+        game = self._make_game_with_milestones("p1", ["Terraformer"], total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_lose_with_0_milestones_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import NO_MILESTONE_WIN
+        ev = SingleGameThresholdEvaluator(NO_MILESTONE_WIN, extractor=_no_milestone_win_extractor)
+        game = self._make_game_with_milestones("p1", [], total_points=50, opponent_points=80)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_tied_first_with_0_milestones_unlocks(self):
+        from services.achievement_evaluators.definitions import NO_MILESTONE_WIN
+        ev = SingleGameThresholdEvaluator(NO_MILESTONE_WIN, extractor=_no_milestone_win_extractor)
+        # Same total points and same MC = real tie, both position 1
+        game = self._make_game_with_milestones("p1", [], total_points=80, opponent_points=80, opponent_mc=30)
+        assert ev.compute_tier("p1", [game]) == 1
+        assert ev.compute_tier("opponent", [game]) == 1
+
+
+# ── Award-based achievement helpers ──────────────────────────────────────────
+
+def _make_award(award_name, opened_by, first_place, second_place=None):
+    from models.award_result import AwardResult
+    from models.enums import Award
+    return AwardResult(
+        award=Award(award_name),
+        opened_by=opened_by,
+        first_place=first_place,
+        second_place=second_place or [],
+    )
+
+
+def _make_game_with_awards(player_id, awards, total_points, opponent_points=20, opponent_mc=30):
+    """Create a game with specific awards and points."""
+    player_score = make_player_score(terraform_rating=total_points)
+    opponent_score = make_player_score(terraform_rating=opponent_points)
+    return Game(
+        game_id="g1",
+        date=date(2026, 1, 1),
+        map_name=MapName.THARSIS,
+        expansions=[],
+        draft=False,
+        generations=10,
+        player_results=[
+            PlayerResult(player_id=player_id, corporation=Corporation.CREDICOR,
+                         scores=player_score, end_stats=PlayerEndStats(mc_total=30)),
+            PlayerResult(player_id="opponent", corporation=Corporation.CREDICOR,
+                         scores=opponent_score, end_stats=PlayerEndStats(mc_total=opponent_mc)),
+        ],
+        awards=awards,
+    )
+
+
+# ── Award Master (SingleGameThreshold) Tests ─────────────────────────────────
+
+class TestAwardMaster:
+    def test_win_with_3_first_place_awards_unlocks(self):
+        from services.achievement_evaluators.definitions import AWARD_MASTER
+        ev = SingleGameThresholdEvaluator(AWARD_MASTER, extractor=_award_master_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["p1"]),
+            _make_award("Banker", "p1", ["p1"]),
+            _make_award("Scientist", "opponent", ["p1"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_win_with_2_first_place_awards_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import AWARD_MASTER
+        ev = SingleGameThresholdEvaluator(AWARD_MASTER, extractor=_award_master_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["p1"]),
+            _make_award("Banker", "p1", ["p1"]),
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_lose_with_3_first_place_awards_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import AWARD_MASTER
+        ev = SingleGameThresholdEvaluator(AWARD_MASTER, extractor=_award_master_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["p1"]),
+            _make_award("Banker", "p1", ["p1"]),
+            _make_award("Scientist", "p1", ["p1"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=50, opponent_points=80)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_shared_first_place_counts(self):
+        from services.achievement_evaluators.definitions import AWARD_MASTER
+        ev = SingleGameThresholdEvaluator(AWARD_MASTER, extractor=_award_master_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["p1", "opponent"]),
+            _make_award("Banker", "p1", ["p1"]),
+            _make_award("Scientist", "p1", ["p1", "opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+
+# ── No Award Win (SingleGameThreshold) Tests ─────────────────────────────────
+
+class TestNoAwardWin:
+    def test_win_with_no_first_place_awards_unlocks(self):
+        from services.achievement_evaluators.definitions import NO_AWARD_WIN
+        ev = SingleGameThresholdEvaluator(NO_AWARD_WIN, extractor=_no_award_win_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["opponent"]),
+            _make_award("Banker", "opponent", ["opponent"]),
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_win_with_one_first_place_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import NO_AWARD_WIN
+        ev = SingleGameThresholdEvaluator(NO_AWARD_WIN, extractor=_no_award_win_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["p1"]),
+            _make_award("Banker", "opponent", ["opponent"]),
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_lose_with_no_first_place_does_not_unlock(self):
+        from services.achievement_evaluators.definitions import NO_AWARD_WIN
+        ev = SingleGameThresholdEvaluator(NO_AWARD_WIN, extractor=_no_award_win_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["opponent"]),
+            _make_award("Banker", "opponent", ["opponent"]),
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=50, opponent_points=80)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_no_awards_in_game_unlocks(self):
+        from services.achievement_evaluators.definitions import NO_AWARD_WIN
+        ev = SingleGameThresholdEvaluator(NO_AWARD_WIN, extractor=_no_award_win_extractor)
+        game = _make_game_with_awards("p1", [], total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+
+# ── Stolen Awards (SingleGameThreshold) Tests ────────────────────────────────
+
+class TestStolenAwards:
+    def test_steal_1_award_unlocks_tier_1(self):
+        from services.achievement_evaluators.definitions import STOLEN_AWARDS
+        ev = SingleGameThresholdEvaluator(STOLEN_AWARDS, extractor=_stolen_awards_extractor)
+        awards = [
+            _make_award("Landlord", "opponent", ["p1"]),       # stolen: sole 1st, not opener
+            _make_award("Banker", "p1", ["p1"]),               # not stolen: p1 opened it
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_steal_3_awards_unlocks_tier_3(self):
+        from services.achievement_evaluators.definitions import STOLEN_AWARDS
+        ev = SingleGameThresholdEvaluator(STOLEN_AWARDS, extractor=_stolen_awards_extractor)
+        awards = [
+            _make_award("Landlord", "opponent", ["p1"]),
+            _make_award("Banker", "opponent", ["p1"]),
+            _make_award("Scientist", "opponent", ["p1"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 3
+
+    def test_shared_first_place_does_not_count_as_stolen(self):
+        from services.achievement_evaluators.definitions import STOLEN_AWARDS
+        ev = SingleGameThresholdEvaluator(STOLEN_AWARDS, extractor=_stolen_awards_extractor)
+        awards = [
+            _make_award("Landlord", "opponent", ["p1", "opponent"]),  # shared, not sole
+            _make_award("Banker", "opponent", ["p1"]),                # stolen
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_opened_by_self_does_not_count(self):
+        from services.achievement_evaluators.definitions import STOLEN_AWARDS
+        ev = SingleGameThresholdEvaluator(STOLEN_AWARDS, extractor=_stolen_awards_extractor)
+        awards = [
+            _make_award("Landlord", "p1", ["p1"]),   # p1 opened it, not stolen
+            _make_award("Banker", "p1", ["p1"]),
+            _make_award("Scientist", "p1", ["p1"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_no_stolen_awards_tier_0(self):
+        from services.achievement_evaluators.definitions import STOLEN_AWARDS
+        ev = SingleGameThresholdEvaluator(STOLEN_AWARDS, extractor=_stolen_awards_extractor)
+        awards = [
+            _make_award("Landlord", "opponent", ["opponent"]),
+            _make_award("Banker", "opponent", ["opponent"]),
+            _make_award("Scientist", "opponent", ["opponent"]),
+        ]
+        game = _make_game_with_awards("p1", awards, total_points=80, opponent_points=50)
+        assert ev.compute_tier("p1", [game]) == 0
+
+
+# ── Card Points (SingleGameThreshold) Tests ──────────────────────────────────
+
+class TestCardPoints:
+    def test_card_points_tier_1(self):
+        from services.achievement_evaluators.definitions import CARD_POINTS
+        ev = SingleGameThresholdEvaluator(CARD_POINTS, extractor=_card_points_extractor)
+        game = make_game(["p1", "p2"], scores_by_player={"p1": 20, "p2": 20})
+        # Default make_player_score has card_points=0, need custom score
+        game.player_results[0].scores.card_points = 15
+        assert ev.compute_tier("p1", [game]) == 1
+
+    def test_card_points_tier_5(self):
+        from services.achievement_evaluators.definitions import CARD_POINTS
+        ev = SingleGameThresholdEvaluator(CARD_POINTS, extractor=_card_points_extractor)
+        game = make_game(["p1", "p2"], scores_by_player={"p1": 20, "p2": 20})
+        game.player_results[0].scores.card_points = 55
+        assert ev.compute_tier("p1", [game]) == 5
+
+    def test_card_points_below_threshold(self):
+        from services.achievement_evaluators.definitions import CARD_POINTS
+        ev = SingleGameThresholdEvaluator(CARD_POINTS, extractor=_card_points_extractor)
+        game = make_game(["p1", "p2"], scores_by_player={"p1": 20, "p2": 20})
+        game.player_results[0].scores.card_points = 5
+        assert ev.compute_tier("p1", [game]) == 0
+
+    def test_card_points_best_across_games(self):
+        from services.achievement_evaluators.definitions import CARD_POINTS
+        ev = SingleGameThresholdEvaluator(CARD_POINTS, extractor=_card_points_extractor)
+        game1 = make_game(["p1", "p2"], scores_by_player={"p1": 20, "p2": 20})
+        game1.player_results[0].scores.card_points = 15
+        game2 = make_game(["p1", "p2"], scores_by_player={"p1": 20, "p2": 20})
+        game2.player_results[0].scores.card_points = 35
+        assert ev.compute_tier("p1", [game1, game2]) == 3  # best is 35 -> tier 3
+
+
 class TestRegistry:
-    def test_all_evaluators_has_six_entries(self):
-        assert len(ALL_EVALUATORS) == 6
+    def test_all_evaluators_has_twelve_entries(self):
+        assert len(ALL_EVALUATORS) == 12
 
     def test_all_codes_unique(self):
         codes = [ev.code for ev in ALL_EVALUATORS]
@@ -391,7 +734,11 @@ class TestRegistry:
 
     def test_expected_codes_present(self):
         codes = {ev.code for ev in ALL_EVALUATORS}
-        assert codes == {"high_score", "games_played", "games_won", "win_streak", "greenery_tiles", "all_maps"}
+        assert codes == {
+            "high_score", "games_played", "games_won", "win_streak", "greenery_tiles",
+            "all_maps", "milestone_master", "no_milestone_win",
+            "award_master", "no_award_win", "stolen_awards", "card_points",
+        }
 
     def test_all_evaluators_are_evaluator_instances(self):
         from services.achievement_evaluators.base import AchievementEvaluator

--- a/frontend/src/components/AchievementIcon/AchievementIcon.tsx
+++ b/frontend/src/components/AchievementIcon/AchievementIcon.tsx
@@ -1,4 +1,4 @@
-import { Trophy, Flame, Map, Gamepad2, Star, Zap, Crown, Trees } from 'lucide-react'
+import { Trophy, Flame, Map, Gamepad2, Star, Zap, Crown, Trees, Shield, Layers } from 'lucide-react'
 import type { LucideProps } from 'lucide-react'
 import styles from './AchievementIcon.module.css'
 
@@ -13,6 +13,8 @@ const ICON_MAP: Record<string, IconComponent> = {
   zap: Zap,
   crown: Crown,
   trees: Trees,
+  shield: Shield,
+  layers: Layers,
 }
 
 interface AchievementIconProps {


### PR DESCRIPTION
## Summary
- **milestone_master**: ganar reclamando los 3 hitos
- **no_milestone_win**: ganar sin reclamar ningún hito
- **award_master**: ganar quedando 1ro en las 3 recompensas
- **no_award_win**: ganar sin quedar 1ro en ninguna recompensa
- **stolen_awards** (3 tiers): robar recompensas (1ro en solitario en award que no abriste)
- **card_points** (5 tiers): puntos de cartas en una partida (10/20/30/40/50)
- Nuevos iconos frontend: Shield, Layers

## Test plan
- [x] Backend: 157 tests passing (`make test-backend`)
- [x] Frontend: 113 tests passing (`npx vitest run`)
- [ ] Verify catalog endpoint: `GET /achievements/catalog`
- [ ] Run reconcile: `POST /achievements/reconcile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)