### PR TITLE
Elo

### DIFF
--- a/backend/db/migrations/versions/add_elo_system.py
+++ b/backend/db/migrations/versions/add_elo_system.py
@@ -1,0 +1,54 @@
+"""add elo system
+
+Revision ID: b8d4e2c5a7f1
+Revises: f3a9b2c1d4e5
+Create Date: 2026-04-23
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'b8d4e2c5a7f1'
+down_revision: Union[str, Sequence[str], None] = 'f3a9b2c1d4e5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "players",
+        sa.Column("elo", sa.Integer(), nullable=False, server_default="1000"),
+    )
+
+    op.create_table(
+        "player_elo_history",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("player_id", sa.String(), nullable=False),
+        sa.Column("game_id", sa.String(), nullable=False),
+        sa.Column("elo_before", sa.Integer(), nullable=False),
+        sa.Column("elo_after", sa.Integer(), nullable=False),
+        sa.Column("delta", sa.Integer(), nullable=False),
+        sa.Column("recorded_at", sa.Date(), nullable=False),
+        sa.ForeignKeyConstraint(["player_id"], ["players.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["game_id"], ["games.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_player_elo_history_player_id",
+        "player_elo_history",
+        ["player_id"],
+    )
+    op.create_index(
+        "ix_player_elo_history_game_id",
+        "player_elo_history",
+        ["game_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_player_elo_history_game_id", table_name="player_elo_history")
+    op.drop_index("ix_player_elo_history_player_id", table_name="player_elo_history")
+    op.drop_table("player_elo_history")
+    op.drop_column("players", "elo")

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -36,10 +36,12 @@ class Player(Base):
     id = Column(String, primary_key=True)
     name = Column(String, nullable=False)
     is_active = Column(Boolean, nullable=False, default=True)
+    elo = Column(Integer, nullable=False, default=1000)
 
     results = relationship("PlayerResult", back_populates="player")
     opened_awards = relationship("Award", back_populates="opened_by_player")
     achievements = relationship("PlayerAchievement", back_populates="player", cascade="all, delete-orphan")
+    elo_history = relationship("PlayerEloHistory", back_populates="player", cascade="all, delete-orphan")
 
 
 class Game(Base):
@@ -107,3 +109,17 @@ class PlayerAchievement(Base):
     )
 
     player = relationship("Player", back_populates="achievements")
+
+
+class PlayerEloHistory(Base):
+    __tablename__ = "player_elo_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    player_id = Column(String, ForeignKey("players.id", ondelete="CASCADE"), nullable=False, index=True)
+    game_id = Column(String, ForeignKey("games.id", ondelete="CASCADE"), nullable=False, index=True)
+    elo_before = Column(Integer, nullable=False)
+    elo_after = Column(Integer, nullable=False)
+    delta = Column(Integer, nullable=False)
+    recorded_at = Column(Date, nullable=False)
+
+    player = relationship("Player", back_populates="elo_history")

--- a/backend/mappers/elo_mapper.py
+++ b/backend/mappers/elo_mapper.py
@@ -1,0 +1,22 @@
+from models.elo_change import EloChange
+from schemas.elo import EloChangeDTO
+
+
+def elo_change_to_dto(change: EloChange, player_name: str) -> EloChangeDTO:
+    return EloChangeDTO(
+        player_id=change.player_id,
+        player_name=player_name,
+        elo_before=change.elo_before,
+        elo_after=change.elo_after,
+        delta=change.delta,
+    )
+
+
+def elo_changes_to_dtos(
+    changes: list[EloChange],
+    players_by_id: dict[str, str],
+) -> list[EloChangeDTO]:
+    return [
+        elo_change_to_dto(c, players_by_id.get(c.player_id, c.player_id))
+        for c in changes
+    ]

--- a/backend/models/elo_change.py
+++ b/backend/models/elo_change.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class EloChange:
+    player_id: str
+    elo_before: int
+    elo_after: int
+    delta: int

--- a/backend/models/player.py
+++ b/backend/models/player.py
@@ -6,7 +6,9 @@ class Player:
         player_id: Optional[str],
         name: str,
         is_active: bool = True,
+        elo: int = 1000,
     ):
         self.player_id = player_id
         self.name = name
         self.is_active = is_active
+        self.elo = elo

--- a/backend/repositories/container.py
+++ b/backend/repositories/container.py
@@ -10,6 +10,7 @@ produces SQLAlchemy sessions from :mod:`db.session`.
 from repositories.game_repository import GamesRepository
 from repositories.player_repository import PlayersRepository
 from repositories.achievement_repository import AchievementRepository
+from repositories.elo_repository import EloRepository
 
 # instantiate concrete repos; additional configuration (e.g. test
 # sessions) can be injected by modifying these variables at startup.
@@ -17,3 +18,4 @@ from repositories.achievement_repository import AchievementRepository
 games_repository = GamesRepository()
 players_repository = PlayersRepository()
 achievement_repository = AchievementRepository()
+elo_repository = EloRepository()

--- a/backend/repositories/elo_repository.py
+++ b/backend/repositories/elo_repository.py
@@ -56,3 +56,32 @@ class EloRepository:
     def has_any_history(self) -> bool:
         with self._session_factory() as session:
             return session.query(PlayerEloHistoryORM.id).first() is not None
+
+    def delete_changes_from_date(self, start_date: date) -> None:
+        with self._session_factory() as session:
+            session.query(PlayerEloHistoryORM).filter(
+                PlayerEloHistoryORM.recorded_at >= start_date
+            ).delete(synchronize_session=False)
+            session.commit()
+
+    def get_baseline_elo_before(self, start_date: date) -> dict[str, int]:
+        """
+        Devuelve el último elo_after por jugador considerando solo registros con
+        recorded_at < start_date. Jugadores sin historial previo quedan ausentes
+        (el caller asigna DEFAULT_ELO).
+        """
+        with self._session_factory() as session:
+            rows = (
+                session.query(PlayerEloHistoryORM)
+                .filter(PlayerEloHistoryORM.recorded_at < start_date)
+                .order_by(
+                    PlayerEloHistoryORM.player_id,
+                    PlayerEloHistoryORM.recorded_at,
+                    PlayerEloHistoryORM.game_id,
+                )
+                .all()
+            )
+            baseline: dict[str, int] = {}
+            for r in rows:
+                baseline[r.player_id] = r.elo_after
+            return baseline

--- a/backend/repositories/elo_repository.py
+++ b/backend/repositories/elo_repository.py
@@ -1,0 +1,58 @@
+from datetime import date
+
+from db.session import get_session
+from db.models import PlayerEloHistory as PlayerEloHistoryORM
+from models.elo_change import EloChange
+
+
+class EloRepository:
+    def __init__(self, session_factory=get_session):
+        self._session_factory = session_factory
+
+    def save_elo_changes(
+        self,
+        game_id: str,
+        recorded_at: date,
+        changes: list[EloChange],
+    ) -> None:
+        with self._session_factory() as session:
+            for change in changes:
+                session.add(
+                    PlayerEloHistoryORM(
+                        player_id=change.player_id,
+                        game_id=game_id,
+                        elo_before=change.elo_before,
+                        elo_after=change.elo_after,
+                        delta=change.delta,
+                        recorded_at=recorded_at,
+                    )
+                )
+            session.commit()
+
+    def get_changes_for_game(self, game_id: str) -> list[EloChange]:
+        with self._session_factory() as session:
+            orms = (
+                session.query(PlayerEloHistoryORM)
+                .filter(PlayerEloHistoryORM.game_id == game_id)
+                .all()
+            )
+            return [
+                EloChange(
+                    player_id=o.player_id,
+                    elo_before=o.elo_before,
+                    elo_after=o.elo_after,
+                    delta=o.delta,
+                )
+                for o in orms
+            ]
+
+    def delete_changes_for_game(self, game_id: str) -> None:
+        with self._session_factory() as session:
+            session.query(PlayerEloHistoryORM).filter(
+                PlayerEloHistoryORM.game_id == game_id
+            ).delete(synchronize_session=False)
+            session.commit()
+
+    def has_any_history(self) -> bool:
+        with self._session_factory() as session:
+            return session.query(PlayerEloHistoryORM.id).first() is not None

--- a/backend/repositories/game_filters.py
+++ b/backend/repositories/game_filters.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
+from datetime import date
 from typing import Optional
 
 
 @dataclass
 class GameFilter:
     game_ids: Optional[set[str]] = None
+    date_from: Optional[date] = None

--- a/backend/repositories/game_repository.py
+++ b/backend/repositories/game_repository.py
@@ -173,4 +173,9 @@ class GamesRepository:
             query = session.query(GameORM)
             if filters and filters.game_ids is not None:
                 query = query.filter(GameORM.id.in_(filters.game_ids))
+            if filters and filters.date_from is not None:
+                query = query.filter(GameORM.date >= filters.date_from)
             return [self._orm_to_domain(g) for g in query.all()]
+
+    def list_games_from_date(self, start_date) -> List[Game]:
+        return self.list_games(GameFilter(date_from=start_date))

--- a/backend/repositories/player_repository.py
+++ b/backend/repositories/player_repository.py
@@ -25,6 +25,7 @@ class PlayersRepository:
                 id=player.player_id,
                 name=player.name,
                 is_active=player.is_active,
+                elo=player.elo,
             )
             session.add(orm)
             session.commit()
@@ -39,6 +40,7 @@ class PlayersRepository:
                 player_id=orm.id,
                 name=orm.name,
                 is_active=orm.is_active,
+                elo=orm.elo,
             )
 
     def update(self, player: Player) -> None:
@@ -48,6 +50,7 @@ class PlayersRepository:
                 raise KeyError(f"Player '{player.player_id}' not found")
             orm.name = player.name
             orm.is_active = player.is_active
+            orm.elo = player.elo
             session.add(orm)
             session.commit()
 
@@ -55,17 +58,18 @@ class PlayersRepository:
         with self._session_factory() as session:
             orms = session.query(PlayerORM).all()
             return [
-                Player(player_id=o.id, name=o.name, is_active=o.is_active)
+                Player(player_id=o.id, name=o.name, is_active=o.is_active, elo=o.elo)
                 for o in orms
             ]
 
-    def get(self, player_id: str) -> Player:
+    def bulk_update_elo(self, elo_by_player: dict[str, int]) -> None:
+        """Persist new ELO values for several players in a single transaction."""
+        if not elo_by_player:
+            return
         with self._session_factory() as session:
-            orm = session.get(PlayerORM, player_id)
-            if not orm:
-                raise KeyError(f"Player '{player_id}' not found")
-            return Player(
-                player_id=orm.id,
-                name=orm.name,
-                is_active=orm.is_active,
-            )
+            for player_id, new_elo in elo_by_player.items():
+                orm = session.get(PlayerORM, player_id)
+                if orm is None:
+                    raise KeyError(f"Player '{player_id}' not found")
+                orm.elo = new_elo
+            session.commit()

--- a/backend/routes/games_routes.py
+++ b/backend/routes/games_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Query
 from typing import Optional
 from services.player_service import PlayerService
 from mappers.record_comparison_mapper import record_comparison_to_dto
+from mappers.elo_mapper import elo_changes_to_dtos
 from schemas.game_records import RecordComparisonDTO
 from schemas.elo import EloChangeDTO
 from services.game_records_service import GameRecordsService
@@ -38,19 +39,6 @@ achievements_service = AchievementsService(
 )
 
 
-def _to_elo_change_dtos(changes, players_by_id) -> list[EloChangeDTO]:
-    return [
-        EloChangeDTO(
-            player_id=c.player_id,
-            player_name=players_by_id.get(c.player_id, c.player_id),
-            elo_before=c.elo_before,
-            elo_after=c.elo_after,
-            delta=c.delta,
-        )
-        for c in changes
-    ]
-
-
 def _player_names_map() -> dict[str, str]:
     return {p.player_id: p.name for p in players_repository.get_all()}
 
@@ -62,7 +50,7 @@ def create_game(game: GameDTO):
         return {
             "id": game_id,
             "game": game,
-            "elo_changes": _to_elo_change_dtos(elo_changes, _player_names_map()),
+            "elo_changes": elo_changes_to_dtos(elo_changes, _player_names_map()),
         }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -94,7 +82,7 @@ def update_game(game_id: str, game: GameDTO):
 
     return {
         "message": "Game updated successfully",
-        "elo_changes": _to_elo_change_dtos(elo_changes, _player_names_map()),
+        "elo_changes": elo_changes_to_dtos(elo_changes, _player_names_map()),
     }
 
 
@@ -128,7 +116,7 @@ def get_game_elo_changes(game_id: str):
         raise HTTPException(status_code=404, detail="Game not found")
 
     changes = elo_repository.get_changes_for_game(game_id)
-    return _to_elo_change_dtos(changes, _player_names_map())
+    return elo_changes_to_dtos(changes, _player_names_map())
 
 
 @router.post("/{game_id}/achievements", response_model=AchievementsByPlayerResponseDTO)

--- a/backend/routes/games_routes.py
+++ b/backend/routes/games_routes.py
@@ -15,6 +15,7 @@ from repositories.container import (
     achievement_repository,
     elo_repository,
 )
+from services.container import elo_service
 from repositories.game_filters import GameFilter
 from services.achievements_service import AchievementsService
 from schemas.achievement import AchievementsByPlayerResponseDTO
@@ -29,7 +30,7 @@ router = APIRouter(
 games_service = GamesService(
     games_repository=games_repository,
     players_repository=players_repository,
-    elo_repository=elo_repository,
+    elo_service=elo_service,
 )
 
 achievements_service = AchievementsService(
@@ -46,12 +47,8 @@ def _player_names_map() -> dict[str, str]:
 @router.post("/", response_model=GameCreatedResponseDTO)
 def create_game(game: GameDTO):
     try:
-        game_id, elo_changes = games_service.create_game(game)
-        return {
-            "id": game_id,
-            "game": game,
-            "elo_changes": elo_changes_to_dtos(elo_changes, _player_names_map()),
-        }
+        game_id = games_service.create_game(game)
+        return {"id": game_id, "game": game}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -76,14 +73,11 @@ def get_game_results(game_id: str):
 @router.put("/{game_id}")
 def update_game(game_id: str, game: GameDTO):
     try:
-        elo_changes = games_service.update_game(game_id, game)
+        games_service.update_game(game_id, game)
     except ValueError:
         raise HTTPException(status_code=404, detail="Game not found")
 
-    return {
-        "message": "Game updated successfully",
-        "elo_changes": elo_changes_to_dtos(elo_changes, _player_names_map()),
-    }
+    return {"message": "Game updated successfully"}
 
 
 

--- a/backend/routes/games_routes.py
+++ b/backend/routes/games_routes.py
@@ -3,11 +3,17 @@ from typing import Optional
 from services.player_service import PlayerService
 from mappers.record_comparison_mapper import record_comparison_to_dto
 from schemas.game_records import RecordComparisonDTO
+from schemas.elo import EloChangeDTO
 from services.game_records_service import GameRecordsService
 from services.game_service import GamesService
 from schemas.game import GameDTO, GameCreatedResponseDTO
 from schemas.result import GameResultDTO
-from repositories.container import games_repository, players_repository, achievement_repository
+from repositories.container import (
+    games_repository,
+    players_repository,
+    achievement_repository,
+    elo_repository,
+)
 from repositories.game_filters import GameFilter
 from services.achievements_service import AchievementsService
 from schemas.achievement import AchievementsByPlayerResponseDTO
@@ -22,6 +28,7 @@ router = APIRouter(
 games_service = GamesService(
     games_repository=games_repository,
     players_repository=players_repository,
+    elo_repository=elo_repository,
 )
 
 achievements_service = AchievementsService(
@@ -30,11 +37,33 @@ achievements_service = AchievementsService(
     players_repository=players_repository,
 )
 
+
+def _to_elo_change_dtos(changes, players_by_id) -> list[EloChangeDTO]:
+    return [
+        EloChangeDTO(
+            player_id=c.player_id,
+            player_name=players_by_id.get(c.player_id, c.player_id),
+            elo_before=c.elo_before,
+            elo_after=c.elo_after,
+            delta=c.delta,
+        )
+        for c in changes
+    ]
+
+
+def _player_names_map() -> dict[str, str]:
+    return {p.player_id: p.name for p in players_repository.get_all()}
+
+
 @router.post("/", response_model=GameCreatedResponseDTO)
 def create_game(game: GameDTO):
     try:
-        game_id = games_service.create_game(game)
-        return {"id": game_id, "game": game}
+        game_id, elo_changes = games_service.create_game(game)
+        return {
+            "id": game_id,
+            "game": game,
+            "elo_changes": _to_elo_change_dtos(elo_changes, _player_names_map()),
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -59,11 +88,14 @@ def get_game_results(game_id: str):
 @router.put("/{game_id}")
 def update_game(game_id: str, game: GameDTO):
     try:
-        games_service.update_game(game_id, game)
+        elo_changes = games_service.update_game(game_id, game)
     except ValueError:
         raise HTTPException(status_code=404, detail="Game not found")
 
-    return {"message": "Game updated successfully"}
+    return {
+        "message": "Game updated successfully",
+        "elo_changes": _to_elo_change_dtos(elo_changes, _player_names_map()),
+    }
 
 
 
@@ -88,6 +120,15 @@ def get_game_records(game_id: str):
         record_comparison_to_dto(c, players)
         for c in comparisons
     ]
+
+
+@router.get("/{game_id}/elo", response_model=list[EloChangeDTO])
+def get_game_elo_changes(game_id: str):
+    if games_repository.get(game_id) is None:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    changes = elo_repository.get_changes_for_game(game_id)
+    return _to_elo_change_dtos(changes, _player_names_map())
 
 
 @router.post("/{game_id}/achievements", response_model=AchievementsByPlayerResponseDTO)

--- a/backend/routes/players_routes.py
+++ b/backend/routes/players_routes.py
@@ -83,6 +83,7 @@ def list_players(active: Optional[bool] = Query(default=None)):
             player_id=p.player_id,
             name=p.name,
             is_active=p.is_active,
+            elo=p.elo,
         )
         for p in players
     ]

--- a/backend/schemas/elo.py
+++ b/backend/schemas/elo.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class EloChangeDTO(BaseModel):
+    player_id: str
+    player_name: str
+    elo_before: int
+    elo_after: int
+    delta: int

--- a/backend/schemas/game.py
+++ b/backend/schemas/game.py
@@ -2,7 +2,6 @@ from typing import List
 from pydantic import BaseModel, Field
 from datetime import date
 from schemas.award import AwardResultDTO
-from schemas.elo import EloChangeDTO
 from models.enums import Expansion, MapName
 from schemas.player import PlayerResultDTO
 
@@ -22,7 +21,6 @@ class GameDTO(BaseModel):
 class GameCreatedResponseDTO(BaseModel):
     id: str
     game: GameDTO
-    elo_changes: List[EloChangeDTO]
 
 
 class GameListItemDTO(BaseModel):

--- a/backend/schemas/game.py
+++ b/backend/schemas/game.py
@@ -2,6 +2,7 @@ from typing import List
 from pydantic import BaseModel, Field
 from datetime import date
 from schemas.award import AwardResultDTO
+from schemas.elo import EloChangeDTO
 from models.enums import Expansion, MapName
 from schemas.player import PlayerResultDTO
 
@@ -21,6 +22,7 @@ class GameDTO(BaseModel):
 class GameCreatedResponseDTO(BaseModel):
     id: str
     game: GameDTO
+    elo_changes: List[EloChangeDTO]
 
 
 class GameListItemDTO(BaseModel):

--- a/backend/schemas/player.py
+++ b/backend/schemas/player.py
@@ -40,3 +40,4 @@ class PlayerResponseDTO(BaseModel):
     player_id: str
     name: str
     is_active: bool
+    elo: int

--- a/backend/schemas/player_profile.py
+++ b/backend/schemas/player_profile.py
@@ -19,6 +19,7 @@ class PlayerGameSummaryDTO(BaseModel):
 
 class PlayerProfileDTO(BaseModel):
     player_id: str
+    elo: int
     stats: PlayerStatsDTO
     games: list[PlayerGameSummaryDTO]
     records: dict[str, bool]

--- a/backend/scripts/seed_elo.py
+++ b/backend/scripts/seed_elo.py
@@ -1,0 +1,81 @@
+"""
+Seed script: calcula y persiste retroactivamente el ELO de todos los jugadores
+a partir de las partidas ya registradas, en orden cronológico.
+
+Es idempotente: si ya hay registros en player_elo_history aborta sin tocar nada.
+
+Usage:
+    cd backend && python scripts/seed_elo.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from repositories.container import (
+    games_repository,
+    players_repository,
+    elo_repository,
+)
+from services.elo_service import calculate_elo_changes, DEFAULT_ELO
+
+
+def seed_elo() -> int:
+    if elo_repository.has_any_history():
+        print(
+            "ABORT: player_elo_history ya tiene registros. "
+            "El seed solo se puede correr sobre una tabla vacía."
+        )
+        return 1
+
+    games = list(games_repository.list().values())
+    if not games:
+        print("No hay partidas registradas. Nada para hacer.")
+        return 0
+
+    games.sort(key=lambda g: (g.date, g.id))
+
+    players = players_repository.get_all()
+    current_elo = {p.player_id: DEFAULT_ELO for p in players}
+
+    print(f"Procesando {len(games)} partidas en orden cronológico...")
+
+    for idx, game in enumerate(games, 1):
+        for pr in game.player_results:
+            current_elo.setdefault(pr.player_id, DEFAULT_ELO)
+
+        elo_snapshot = {
+            pr.player_id: current_elo[pr.player_id]
+            for pr in game.player_results
+        }
+
+        changes = calculate_elo_changes(game, elo_snapshot)
+
+        elo_repository.save_elo_changes(
+            game_id=game.id,
+            recorded_at=game.date,
+            changes=changes,
+        )
+
+        for c in changes:
+            current_elo[c.player_id] = c.elo_after
+
+        print(f"  [{idx}/{len(games)}] {game.date} {game.id[:8]}... ok")
+
+    players_repository.bulk_update_elo(current_elo)
+
+    print("\nELO final por jugador:")
+    name_by_id = {p.player_id: p.name for p in players}
+    for player_id, elo in sorted(
+        current_elo.items(), key=lambda kv: -kv[1]
+    ):
+        name = name_by_id.get(player_id, player_id)
+        print(f"  {name:<20} {elo}")
+
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(seed_elo())

--- a/backend/scripts/seed_elo.py
+++ b/backend/scripts/seed_elo.py
@@ -2,7 +2,8 @@
 Seed script: calcula y persiste retroactivamente el ELO de todos los jugadores
 a partir de las partidas ya registradas, en orden cronológico.
 
-Es idempotente: si ya hay registros en player_elo_history aborta sin tocar nada.
+Es idempotente a nivel seed: si ya hay registros en player_elo_history aborta
+sin tocar nada. La lógica de recálculo vive en EloService.recompute_all().
 
 Usage:
     cd backend && python scripts/seed_elo.py
@@ -13,12 +14,8 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from repositories.container import (
-    games_repository,
-    players_repository,
-    elo_repository,
-)
-from services.elo_service import calculate_elo_changes, DEFAULT_ELO
+from repositories.container import elo_repository, players_repository
+from services.container import elo_service
 
 
 def seed_elo() -> int:
@@ -29,49 +26,17 @@ def seed_elo() -> int:
         )
         return 1
 
-    games = list(games_repository.list().values())
-    if not games:
-        print("No hay partidas registradas. Nada para hacer.")
+    if not players_repository.get_all():
+        print("No hay jugadores registrados. Nada para hacer.")
         return 0
 
-    games.sort(key=lambda g: (g.date, g.id))
+    print("Procesando partidas en orden cronológico...")
+    elo_service.recompute_all()
 
     players = players_repository.get_all()
-    current_elo = {p.player_id: DEFAULT_ELO for p in players}
-
-    print(f"Procesando {len(games)} partidas en orden cronológico...")
-
-    for idx, game in enumerate(games, 1):
-        for pr in game.player_results:
-            current_elo.setdefault(pr.player_id, DEFAULT_ELO)
-
-        elo_snapshot = {
-            pr.player_id: current_elo[pr.player_id]
-            for pr in game.player_results
-        }
-
-        changes = calculate_elo_changes(game, elo_snapshot)
-
-        elo_repository.save_elo_changes(
-            game_id=game.id,
-            recorded_at=game.date,
-            changes=changes,
-        )
-
-        for c in changes:
-            current_elo[c.player_id] = c.elo_after
-
-        print(f"  [{idx}/{len(games)}] {game.date} {game.id[:8]}... ok")
-
-    players_repository.bulk_update_elo(current_elo)
-
     print("\nELO final por jugador:")
-    name_by_id = {p.player_id: p.name for p in players}
-    for player_id, elo in sorted(
-        current_elo.items(), key=lambda kv: -kv[1]
-    ):
-        name = name_by_id.get(player_id, player_id)
-        print(f"  {name:<20} {elo}")
+    for player in sorted(players, key=lambda p: -p.elo):
+        print(f"  {player.name:<20} {player.elo}")
 
     print("\nDone.")
     return 0

--- a/backend/services/container.py
+++ b/backend/services/container.py
@@ -1,0 +1,19 @@
+"""Dependency container for service-layer instances.
+
+Services compose repositories from `repositories.container`. Routes import
+service singletons from this module. Repositories never live here.
+"""
+
+from repositories.container import (
+    elo_repository,
+    games_repository,
+    players_repository,
+)
+from services.elo_service import EloService
+
+
+elo_service = EloService(
+    elo_repository=elo_repository,
+    players_repository=players_repository,
+    games_repository=games_repository,
+)

--- a/backend/services/elo_service.py
+++ b/backend/services/elo_service.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from models.elo_change import EloChange
 from models.game import Game
 from services.helpers.results import calculate_results
@@ -63,3 +65,51 @@ def calculate_elo_changes(
         )
 
     return changes
+
+
+class EloService:
+    """
+    Encapsula la persistencia y recomputación de ELO.
+
+    `recompute_from_date` es la única vía de mutación: dada una fecha de partida
+    afectada, re-procesa todas las partidas con date >= start_date en orden
+    cronológico, dejando el historial y players.elo consistentes.
+    """
+
+    def __init__(self, elo_repository, players_repository, games_repository):
+        self.elo_repository = elo_repository
+        self.players_repository = players_repository
+        self.games_repository = games_repository
+
+    def recompute_from_date(self, start_date: date) -> None:
+        baseline = self._build_baseline(start_date)
+        self.elo_repository.delete_changes_from_date(start_date)
+        games = self.games_repository.list_games_from_date(start_date)
+        self._walk_and_persist(games, baseline)
+        self.players_repository.bulk_update_elo(baseline)
+
+    def recompute_all(self) -> None:
+        self.recompute_from_date(date.min)
+
+    def _build_baseline(self, start_date: date) -> dict[str, int]:
+        baseline = {p.player_id: DEFAULT_ELO for p in self.players_repository.get_all()}
+        baseline.update(self.elo_repository.get_baseline_elo_before(start_date))
+        return baseline
+
+    def _walk_and_persist(self, games: list[Game], baseline: dict[str, int]) -> None:
+        games.sort(key=lambda g: (g.date, g.id))
+        for game in games:
+            for pr in game.player_results:
+                baseline.setdefault(pr.player_id, DEFAULT_ELO)
+            snapshot = {
+                pr.player_id: baseline[pr.player_id]
+                for pr in game.player_results
+            }
+            changes = calculate_elo_changes(game, snapshot)
+            self.elo_repository.save_elo_changes(
+                game_id=game.id,
+                recorded_at=game.date,
+                changes=changes,
+            )
+            for c in changes:
+                baseline[c.player_id] = c.elo_after

--- a/backend/services/elo_service.py
+++ b/backend/services/elo_service.py
@@ -1,0 +1,65 @@
+from models.elo_change import EloChange
+from models.game import Game
+from services.helpers.results import calculate_results
+
+
+K_FACTOR = 32
+DEFAULT_ELO = 1000
+
+
+def _expected_score(rating_a: int, rating_b: int) -> float:
+    return 1.0 / (1.0 + 10 ** ((rating_b - rating_a) / 400))
+
+
+def _actual_score(position_a: int, position_b: int) -> float:
+    if position_a < position_b:
+        return 1.0
+    if position_a > position_b:
+        return 0.0
+    return 0.5
+
+
+def calculate_elo_changes(
+    game: Game,
+    current_elo_by_player: dict[str, int],
+) -> list[EloChange]:
+    """
+    Calcula los cambios de ELO para todos los jugadores de una partida usando
+    comparaciones por pares (cada jugador se enfrenta a todos los demás).
+
+    Args:
+        game: la partida ya rankeada (se usa calculate_results para las posiciones).
+        current_elo_by_player: mapa player_id -> ELO actual antes de la partida.
+
+    Returns:
+        Lista de EloChange con elo_before, elo_after y delta por jugador.
+    """
+    results = calculate_results(game).results
+    positions = {r.player_id: r.position for r in results}
+    player_ids = [r.player_id for r in results]
+
+    changes: list[EloChange] = []
+    for player_id in player_ids:
+        elo_before = current_elo_by_player[player_id]
+        delta_sum = 0.0
+
+        for opponent_id in player_ids:
+            if opponent_id == player_id:
+                continue
+
+            opponent_elo = current_elo_by_player[opponent_id]
+            expected = _expected_score(elo_before, opponent_elo)
+            actual = _actual_score(positions[player_id], positions[opponent_id])
+            delta_sum += (actual - expected)
+
+        delta = round(K_FACTOR * delta_sum)
+        changes.append(
+            EloChange(
+                player_id=player_id,
+                elo_before=elo_before,
+                elo_after=elo_before + delta,
+                delta=delta,
+            )
+        )
+
+    return changes

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -1,9 +1,12 @@
 from models.player_result import PlayerResult
+from models.elo_change import EloChange
+from models.game import Game
 from schemas.game import GameDTO
 from datetime import date
 from models.award_result import AwardResult
 from models.enums import Corporation
 from services.helpers.results import calculate_results
+from services.elo_service import calculate_elo_changes, DEFAULT_ELO
 from schemas.result import GameResultDTO
 from mappers.game_mapper import game_dto_to_model
 from mappers.game_mapper import game_model_to_dto
@@ -12,9 +15,10 @@ from repositories.game_filters import GameFilter
 
 
 class GamesService:
-    def __init__(self, games_repository, players_repository):
+    def __init__(self, games_repository, players_repository, elo_repository=None):
         self.games_repository = games_repository
         self.players_repository = players_repository
+        self.elo_repository = elo_repository
 
 
     def _validate_date(self, game_date: date):
@@ -28,7 +32,7 @@ class GamesService:
         ids = [p.player_id for p in players]
         if len(ids) != len(set(ids)):
             raise ValueError("Duplicate players are not allowed")
-        
+
     def _validate_corporations(self, players: list[PlayerResult]) -> None:
         seen: set = set()
         for player in players:
@@ -42,7 +46,7 @@ class GamesService:
                 raise ValueError(
                     f"Corporation '{corp}' was chosen by more than one player")
             seen.add(corp)
-    
+
     def _validate_milestones(self, players: list[PlayerResult]) -> None:
         total = sum(len(player.scores.milestones) for player in players)
 
@@ -80,7 +84,7 @@ class GamesService:
             raise ValueError(
                 f"A game can have at most 3 awards (got {len(awards)})"
             )
-    
+
     def _validate_unique_awards(self, awards: list[AwardResult]) -> None:
         award_names = [award.award for award in awards]
 
@@ -128,16 +132,16 @@ class GamesService:
                 raise ValueError(
                     f"Award '{award.award}' cannot have second place in a 2-player game"
                 )
-            
+
     def _validate_players_exist(self, player_results: list[PlayerResult]):
         for pr in player_results:
             try:
                 self.players_repository.get(pr.player_id)
             except KeyError:
                 raise ValueError(f"Player '{pr.player_id}' is not registered")
-    
 
-    def create_game(self, game_dto: GameDTO) -> str:
+
+    def create_game(self, game_dto: GameDTO) -> tuple[str, list[EloChange]]:
         # Mapear a dominio
         game = game_dto_to_model(game_dto)
 
@@ -154,33 +158,44 @@ class GamesService:
         self._validate_award_ties(game.awards, len(game.player_results))
         self._validate_players_exist(game.player_results)
 
-        return self.games_repository.create(game)
+        game_id = self.games_repository.create(game)
+        game.id = game_id
+
+        elo_changes = self._apply_elo_for_game(game)
+        return game_id, elo_changes
 
 
     def list_games(self, filters: GameFilter | None = None) -> list[GameDTO]:
         games = self.games_repository.list_games(filters)
         return [game_model_to_dto(game) for game in games]
 
-        
-    def update_game(self, game_id: str, game_dto: GameDTO) -> None:
+
+    def update_game(self, game_id: str, game_dto: GameDTO) -> list[EloChange]:
         game = game_dto_to_model(game_dto)
 
-        updated = self.games_repository.update(game_id, game)
-
-        if not updated:
+        if self.games_repository.get(game_id) is None:
             raise ValueError("Game not found")
 
-        
+        self._revert_elo_for_game(game_id)
+
+        self.games_repository.update(game_id, game)
+
+        game.id = game_id
+        return self._apply_elo_for_game(game)
+
+
     def delete_game(self, game_id: str) -> None:
         """
         Elimina una partida.
         Lanza error si no existe.
         """
+        self._revert_elo_for_game(game_id)
+
         deleted = self.games_repository.delete(game_id)
 
         if not deleted:
             raise ValueError("Game not found")
-        
+
     def get_game_results(self, game_id: str) -> GameResultDTO:
         game = self.games_repository.get(game_id)
 
@@ -188,3 +203,39 @@ class GamesService:
             raise ValueError("Game not found")
 
         return calculate_results(game)
+
+    def _apply_elo_for_game(self, game: Game) -> list[EloChange]:
+        """Calcula y persiste los cambios de ELO para una partida ya guardada."""
+        if self.elo_repository is None:
+            return []
+
+        current_elo_by_player = {
+            pr.player_id: self.players_repository.get(pr.player_id).elo
+            for pr in game.player_results
+        }
+
+        changes = calculate_elo_changes(game, current_elo_by_player)
+
+        self.elo_repository.save_elo_changes(
+            game_id=game.id,
+            recorded_at=game.date,
+            changes=changes,
+        )
+        self.players_repository.bulk_update_elo(
+            {c.player_id: c.elo_after for c in changes}
+        )
+        return changes
+
+    def _revert_elo_for_game(self, game_id: str) -> None:
+        """Revierte los cambios de ELO de una partida usando el historial."""
+        if self.elo_repository is None:
+            return
+
+        previous_changes = self.elo_repository.get_changes_for_game(game_id)
+        if not previous_changes:
+            return
+
+        self.players_repository.bulk_update_elo(
+            {c.player_id: c.elo_before for c in previous_changes}
+        )
+        self.elo_repository.delete_changes_for_game(game_id)

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -1,24 +1,21 @@
-from models.player_result import PlayerResult
-from models.elo_change import EloChange
-from models.game import Game
-from schemas.game import GameDTO
 from datetime import date
+
+from models.player_result import PlayerResult
 from models.award_result import AwardResult
 from models.enums import Corporation
-from services.helpers.results import calculate_results
-from services.elo_service import calculate_elo_changes, DEFAULT_ELO
+from schemas.game import GameDTO
 from schemas.result import GameResultDTO
-from mappers.game_mapper import game_dto_to_model
-from mappers.game_mapper import game_model_to_dto
+from services.helpers.results import calculate_results
+from mappers.game_mapper import game_dto_to_model, game_model_to_dto
 from repositories.game_filters import GameFilter
 
 
 
 class GamesService:
-    def __init__(self, games_repository, players_repository, elo_repository=None):
+    def __init__(self, games_repository, players_repository, elo_service=None):
         self.games_repository = games_repository
         self.players_repository = players_repository
-        self.elo_repository = elo_repository
+        self.elo_service = elo_service
 
 
     def _validate_date(self, game_date: date):
@@ -141,7 +138,7 @@ class GamesService:
                 raise ValueError(f"Player '{pr.player_id}' is not registered")
 
 
-    def create_game(self, game_dto: GameDTO) -> tuple[str, list[EloChange]]:
+    def create_game(self, game_dto: GameDTO) -> str:
         # Mapear a dominio
         game = game_dto_to_model(game_dto)
 
@@ -161,8 +158,8 @@ class GamesService:
         game_id = self.games_repository.create(game)
         game.id = game_id
 
-        elo_changes = self._apply_elo_for_game(game)
-        return game_id, elo_changes
+        self._recompute_elo_from(game.date)
+        return game_id
 
 
     def list_games(self, filters: GameFilter | None = None) -> list[GameDTO]:
@@ -170,18 +167,17 @@ class GamesService:
         return [game_model_to_dto(game) for game in games]
 
 
-    def update_game(self, game_id: str, game_dto: GameDTO) -> list[EloChange]:
-        game = game_dto_to_model(game_dto)
+    def update_game(self, game_id: str, game_dto: GameDTO) -> None:
+        new_game = game_dto_to_model(game_dto)
 
-        if self.games_repository.get(game_id) is None:
+        old_game = self.games_repository.get(game_id)
+        if old_game is None:
             raise ValueError("Game not found")
 
-        self._revert_elo_for_game(game_id)
+        self.games_repository.update(game_id, new_game)
 
-        self.games_repository.update(game_id, game)
-
-        game.id = game_id
-        return self._apply_elo_for_game(game)
+        affected_date = min(old_game.date, new_game.date)
+        self._recompute_elo_from(affected_date)
 
 
     def delete_game(self, game_id: str) -> None:
@@ -189,12 +185,15 @@ class GamesService:
         Elimina una partida.
         Lanza error si no existe.
         """
-        self._revert_elo_for_game(game_id)
+        old_game = self.games_repository.get(game_id)
+        if old_game is None:
+            raise ValueError("Game not found")
 
         deleted = self.games_repository.delete(game_id)
-
         if not deleted:
             raise ValueError("Game not found")
+
+        self._recompute_elo_from(old_game.date)
 
     def get_game_results(self, game_id: str) -> GameResultDTO:
         game = self.games_repository.get(game_id)
@@ -204,38 +203,7 @@ class GamesService:
 
         return calculate_results(game)
 
-    def _apply_elo_for_game(self, game: Game) -> list[EloChange]:
-        """Calcula y persiste los cambios de ELO para una partida ya guardada."""
-        if self.elo_repository is None:
-            return []
-
-        current_elo_by_player = {
-            pr.player_id: self.players_repository.get(pr.player_id).elo
-            for pr in game.player_results
-        }
-
-        changes = calculate_elo_changes(game, current_elo_by_player)
-
-        self.elo_repository.save_elo_changes(
-            game_id=game.id,
-            recorded_at=game.date,
-            changes=changes,
-        )
-        self.players_repository.bulk_update_elo(
-            {c.player_id: c.elo_after for c in changes}
-        )
-        return changes
-
-    def _revert_elo_for_game(self, game_id: str) -> None:
-        """Revierte los cambios de ELO de una partida usando el historial."""
-        if self.elo_repository is None:
+    def _recompute_elo_from(self, start_date: date) -> None:
+        if self.elo_service is None:
             return
-
-        previous_changes = self.elo_repository.get_changes_for_game(game_id)
-        if not previous_changes:
-            return
-
-        self.players_repository.bulk_update_elo(
-            {c.player_id: c.elo_before for c in previous_changes}
-        )
-        self.elo_repository.delete_changes_for_game(game_id)
+        self.elo_service.recompute_from_date(start_date)

--- a/backend/services/player_profile_service.py
+++ b/backend/services/player_profile_service.py
@@ -19,9 +19,9 @@ class PlayerProfileService:
         self.player_records_service = player_records_service
 
     def get_profile(self, player_id: str) -> PlayerProfileDTO:
-        
+
         # validar que el jugador exista
-        self.players_repository.get(player_id)
+        player = self.players_repository.get(player_id)
 
         games = self.games_repository.get_games_by_player(player_id)
 
@@ -98,8 +98,9 @@ class PlayerProfileService:
         # usar directamente el id
         return PlayerProfileDTO(
             player_id=player_id,
+            elo=player.elo,
             stats=stats,
             games=summaries,
             records=records,
-        )    
+        )
 

--- a/backend/tests/integration/test_elo_cascade.py
+++ b/backend/tests/integration/test_elo_cascade.py
@@ -1,0 +1,235 @@
+"""
+Integration tests for ELO cascade recompute on game create/update/delete.
+
+Invariant: after any sequence of mutations, the persisted state must equal the
+state produced by recomputing ELO from scratch over the current game set.
+"""
+from datetime import date
+
+import pytest
+
+from fastapi.testclient import TestClient
+from main import app
+from models.player import Player
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def players_repo():
+    from repositories.player_repository import PlayersRepository
+    return PlayersRepository()
+
+
+@pytest.fixture
+def elo_repo():
+    from repositories.elo_repository import EloRepository
+    return EloRepository()
+
+
+def _player_result(player_id: str, terraform_rating: int, corp: str = "Credicor") -> dict:
+    return {
+        "player_id": player_id,
+        "corporation": corp,
+        "scores": {
+            "terraform_rating": terraform_rating,
+            "milestone_points": 0,
+            "milestones": [],
+            "award_points": 0,
+            "card_points": 0,
+            "card_resource_points": 0,
+            "greenery_points": 0,
+            "city_points": 0,
+            "turmoil_points": None,
+        },
+        "end_stats": {"mc_total": 0},
+    }
+
+
+# Distinct corps per player so each game passes the unique-corp validation.
+_CORP_BY_PLAYER = {"p1": "Credicor", "p2": "Ecoline", "p3": "Helion"}
+
+
+def _pr(player_id: str, terraform_rating: int) -> dict:
+    return _player_result(player_id, terraform_rating, _CORP_BY_PLAYER[player_id])
+
+
+def _game_payload(game_id: str, on_date: str, results: list[dict]) -> dict:
+    return {
+        "id": game_id,
+        "date": on_date,
+        "map": "Hellas",
+        "expansions": [],
+        "draft": False,
+        "generations": 10,
+        "player_results": results,
+        "awards": [],
+    }
+
+
+def _post_game(client, payload: dict) -> str:
+    res = client.post("/games/", json=payload)
+    assert res.status_code == 200, res.json()
+    return res.json()["id"]
+
+
+def _final_elo_snapshot(players_repo, ids: list[str]) -> dict[str, int]:
+    return {pid: players_repo.get(pid).elo for pid in ids}
+
+
+def _seed_three_players(players_repo) -> list[str]:
+    players_repo.create(Player(player_id="p1", name="Alice"))
+    players_repo.create(Player(player_id="p2", name="Bob"))
+    players_repo.create(Player(player_id="p3", name="Cara"))
+    return ["p1", "p2", "p3"]
+
+
+def _post_three_games(client) -> tuple[str, str, str]:
+    g1 = _post_game(client, _game_payload(
+        "g-d1", "2026-01-01",
+        [_pr("p1", 50), _pr("p2", 30), _pr("p3", 20)],
+    ))
+    g2 = _post_game(client, _game_payload(
+        "g-d2", "2026-02-01",
+        [_pr("p2", 50), _pr("p3", 30), _pr("p1", 20)],
+    ))
+    g3 = _post_game(client, _game_payload(
+        "g-d3", "2026-03-01",
+        [_pr("p3", 50), _pr("p1", 30), _pr("p2", 20)],
+    ))
+    return g1, g2, g3
+
+
+class TestResponseShape:
+    def test_post_response_excludes_elo_changes(self, client, players_repo):
+        _seed_three_players(players_repo)
+        payload = _game_payload(
+            "g-shape-1", "2026-01-01",
+            [_pr("p1", 50), _pr("p2", 30)],
+        )
+        res = client.post("/games/", json=payload)
+        assert res.status_code == 200
+        body = res.json()
+        assert "id" in body
+        assert "game" in body
+        assert "elo_changes" not in body
+
+    def test_put_response_excludes_elo_changes(self, client, players_repo):
+        _seed_three_players(players_repo)
+        gid = _post_game(client, _game_payload(
+            "g-shape-2", "2026-01-01",
+            [_pr("p1", 50), _pr("p2", 30)],
+        ))
+
+        update_payload = _game_payload(
+            "g-shape-2", "2026-01-01",
+            [_pr("p1", 30), _pr("p2", 50)],
+        )
+        res = client.put(f"/games/{gid}", json=update_payload)
+        assert res.status_code == 200
+        body = res.json()
+        assert body == {"message": "Game updated successfully"}
+
+
+class TestCascadeInvariant:
+    def test_delete_then_recreate_yields_same_final_state(self, client, players_repo):
+        ids = _seed_three_players(players_repo)
+        g1, g2, g3 = _post_three_games(client)
+
+        baseline = _final_elo_snapshot(players_repo, ids)
+
+        # Delete the middle game...
+        res = client.delete(f"/games/{g2}")
+        assert res.status_code == 200
+        # ...then re-create it identically.
+        _post_game(client, _game_payload(
+            g2, "2026-02-01",
+            [_pr("p2", 50), _pr("p3", 30), _pr("p1", 20)],
+        ))
+
+        after = _final_elo_snapshot(players_repo, ids)
+        assert after == baseline
+
+    def test_delete_middle_changes_subsequent_history(self, client, players_repo, elo_repo):
+        ids = _seed_three_players(players_repo)
+        g1, g2, g3 = _post_three_games(client)
+
+        before = elo_repo.get_changes_for_game(g3)
+        client.delete(f"/games/{g2}")
+        after = elo_repo.get_changes_for_game(g3)
+
+        before_by_player = {c.player_id: c for c in before}
+        after_by_player = {c.player_id: c for c in after}
+        # Every player in g3 must see different elo_before because g2 no longer
+        # contributed to their snapshot.
+        for pid, c in after_by_player.items():
+            assert c.elo_before != before_by_player[pid].elo_before
+
+    def test_modify_middle_changes_subsequent_history(self, client, players_repo, elo_repo):
+        _seed_three_players(players_repo)
+        g1, g2, g3 = _post_three_games(client)
+
+        before = {c.player_id: c.elo_before for c in elo_repo.get_changes_for_game(g3)}
+
+        # Flip the order of g2: p1 wins instead of p2
+        client.put(f"/games/{g2}", json=_game_payload(
+            g2, "2026-02-01",
+            [_pr("p1", 50), _pr("p2", 30), _pr("p3", 20)],
+        ))
+
+        after = {c.player_id: c.elo_before for c in elo_repo.get_changes_for_game(g3)}
+        assert after != before
+
+    def test_create_backdated_recomputes_subsequent_games(self, client, players_repo, elo_repo):
+        _seed_three_players(players_repo)
+        g1, g2, g3 = _post_three_games(client)
+
+        # Snapshot g3's history before the backdated insert
+        before = {c.player_id: c.elo_before for c in elo_repo.get_changes_for_game(g3)}
+
+        # Insert a game with an earlier date than all existing ones
+        _post_game(client, _game_payload(
+            "g-d0", "2025-12-01",
+            [_pr("p3", 50), _pr("p2", 30), _pr("p1", 20)],
+        ))
+
+        after = {c.player_id: c.elo_before for c in elo_repo.get_changes_for_game(g3)}
+        assert after != before
+
+    def test_player_elo_matches_last_history_after_after_mutations(
+        self, client, players_repo, elo_repo
+    ):
+        ids = _seed_three_players(players_repo)
+        g1, g2, g3 = _post_three_games(client)
+
+        client.delete(f"/games/{g2}")
+
+        for pid in ids:
+            history = sorted(
+                _all_history_for_player(elo_repo, pid),
+                key=lambda c: c["recorded_at"],
+            )
+            if not history:
+                assert players_repo.get(pid).elo == 1000
+            else:
+                assert players_repo.get(pid).elo == history[-1]["elo_after"]
+
+
+def _all_history_for_player(elo_repo, player_id: str) -> list[dict]:
+    """Read every history row across all games for a player."""
+    from db.session import get_session
+    from db.models import PlayerEloHistory as PlayerEloHistoryORM
+
+    with get_session() as session:
+        rows = (
+            session.query(PlayerEloHistoryORM)
+            .filter(PlayerEloHistoryORM.player_id == player_id)
+            .all()
+        )
+        return [
+            {"recorded_at": r.recorded_at, "elo_after": r.elo_after, "game_id": r.game_id}
+            for r in rows
+        ]

--- a/backend/tests/test_elo_recomputer.py
+++ b/backend/tests/test_elo_recomputer.py
@@ -1,0 +1,153 @@
+"""Unit tests for `EloService.recompute_from_date` using mocked repositories."""
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from models.game import Game
+from models.player import Player
+from models.player_result import PlayerResult, PlayerEndStats
+from models.player_score import PlayerScore
+from models.enums import Corporation, MapName
+from services.elo_service import EloService, DEFAULT_ELO
+
+
+def _player_result(player_id: str, terraform_rating: int) -> PlayerResult:
+    scores = PlayerScore(
+        terraform_rating=terraform_rating,
+        milestone_points=0,
+        milestones=[],
+        award_points=0,
+        card_points=0,
+        card_resource_points=0,
+        greenery_points=0,
+        city_points=0,
+        turmoil_points=0,
+    )
+    return PlayerResult(
+        player_id=player_id,
+        corporation=Corporation.CREDICOR,
+        scores=scores,
+        end_stats=PlayerEndStats(mc_total=0),
+    )
+
+
+def _game(game_id: str, on_date: date, players: list[PlayerResult]) -> Game:
+    return Game(
+        game_id=game_id,
+        date=on_date,
+        map_name=MapName.HELLAS,
+        expansions=[],
+        draft=False,
+        generations=10,
+        player_results=players,
+        awards=[],
+    )
+
+
+@pytest.fixture
+def repos():
+    return {
+        "elo": MagicMock(),
+        "players": MagicMock(),
+        "games": MagicMock(),
+    }
+
+
+@pytest.fixture
+def service(repos):
+    return EloService(
+        elo_repository=repos["elo"],
+        players_repository=repos["players"],
+        games_repository=repos["games"],
+    )
+
+
+class TestRecomputeFromDate:
+    def test_no_games_only_does_baseline_update(self, service, repos):
+        repos["players"].get_all.return_value = [
+            Player(player_id="p1", name="Alice"),
+            Player(player_id="p2", name="Bob"),
+        ]
+        repos["elo"].get_baseline_elo_before.return_value = {}
+        repos["games"].list_games_from_date.return_value = []
+
+        service.recompute_from_date(date(2026, 1, 1))
+
+        repos["elo"].delete_changes_from_date.assert_called_once_with(date(2026, 1, 1))
+        repos["elo"].save_elo_changes.assert_not_called()
+        repos["players"].bulk_update_elo.assert_called_once_with(
+            {"p1": DEFAULT_ELO, "p2": DEFAULT_ELO}
+        )
+
+    def test_single_game_persists_changes(self, service, repos):
+        repos["players"].get_all.return_value = [
+            Player(player_id="p1", name="Alice"),
+            Player(player_id="p2", name="Bob"),
+        ]
+        repos["elo"].get_baseline_elo_before.return_value = {}
+        game = _game("g1", date(2026, 1, 1), [
+            _player_result("p1", 50),
+            _player_result("p2", 30),
+        ])
+        repos["games"].list_games_from_date.return_value = [game]
+
+        service.recompute_from_date(date(2026, 1, 1))
+
+        # save_elo_changes called for the single game
+        assert repos["elo"].save_elo_changes.call_count == 1
+        kwargs = repos["elo"].save_elo_changes.call_args.kwargs
+        assert kwargs["game_id"] == "g1"
+        assert kwargs["recorded_at"] == date(2026, 1, 1)
+        # Final bulk update reflects post-game ELO (winner > 1000, loser < 1000)
+        final = repos["players"].bulk_update_elo.call_args.args[0]
+        assert final["p1"] > DEFAULT_ELO
+        assert final["p2"] < DEFAULT_ELO
+
+    def test_baseline_overrides_default_for_known_players(self, service, repos):
+        repos["players"].get_all.return_value = [
+            Player(player_id="p1", name="Alice"),
+            Player(player_id="p2", name="Bob"),
+        ]
+        repos["elo"].get_baseline_elo_before.return_value = {"p1": 1200}
+        repos["games"].list_games_from_date.return_value = []
+
+        service.recompute_from_date(date(2026, 1, 1))
+
+        final = repos["players"].bulk_update_elo.call_args.args[0]
+        assert final["p1"] == 1200  # from baseline
+        assert final["p2"] == DEFAULT_ELO  # default for player without history
+
+    def test_games_processed_in_chronological_order(self, service, repos):
+        repos["players"].get_all.return_value = [
+            Player(player_id="p1", name="Alice"),
+            Player(player_id="p2", name="Bob"),
+        ]
+        repos["elo"].get_baseline_elo_before.return_value = {}
+        # Provide games out of order; service must sort them
+        g_late = _game("g_late", date(2026, 3, 1), [
+            _player_result("p1", 30),
+            _player_result("p2", 50),
+        ])
+        g_early = _game("g_early", date(2026, 1, 1), [
+            _player_result("p1", 50),
+            _player_result("p2", 30),
+        ])
+        repos["games"].list_games_from_date.return_value = [g_late, g_early]
+
+        service.recompute_from_date(date(2026, 1, 1))
+
+        # Two save calls; first must be the early game
+        calls = repos["elo"].save_elo_changes.call_args_list
+        assert calls[0].kwargs["game_id"] == "g_early"
+        assert calls[1].kwargs["game_id"] == "g_late"
+
+    def test_recompute_all_uses_date_min(self, service, repos):
+        repos["players"].get_all.return_value = []
+        repos["elo"].get_baseline_elo_before.return_value = {}
+        repos["games"].list_games_from_date.return_value = []
+
+        service.recompute_all()
+
+        repos["elo"].delete_changes_from_date.assert_called_once_with(date.min)
+        repos["games"].list_games_from_date.assert_called_once_with(date.min)

--- a/backend/tests/test_elo_service.py
+++ b/backend/tests/test_elo_service.py
@@ -1,0 +1,105 @@
+"""Unit tests for the pure ELO function `calculate_elo_changes`."""
+from datetime import date
+
+import pytest
+
+from models.game import Game
+from models.player_result import PlayerResult, PlayerEndStats
+from models.player_score import PlayerScore
+from models.enums import Corporation, MapName
+from services.elo_service import calculate_elo_changes, K_FACTOR
+
+
+def _player(player_id: str, terraform_rating: int) -> PlayerResult:
+    scores = PlayerScore(
+        terraform_rating=terraform_rating,
+        milestone_points=0,
+        milestones=[],
+        award_points=0,
+        card_points=0,
+        card_resource_points=0,
+        greenery_points=0,
+        city_points=0,
+        turmoil_points=0,
+    )
+    return PlayerResult(
+        player_id=player_id,
+        corporation=Corporation.CREDICOR,
+        scores=scores,
+        end_stats=PlayerEndStats(mc_total=0),
+    )
+
+
+def _game(player_results: list[PlayerResult]) -> Game:
+    return Game(
+        game_id="g1",
+        date=date(2026, 1, 1),
+        map_name=MapName.HELLAS,
+        expansions=[],
+        draft=False,
+        generations=10,
+        player_results=player_results,
+        awards=[],
+    )
+
+
+class TestCalculateEloChanges:
+    def test_two_players_equal_elo_winner_takes_half_K(self):
+        game = _game([_player("p1", 50), _player("p2", 30)])
+        changes = calculate_elo_changes(game, {"p1": 1000, "p2": 1000})
+
+        by_id = {c.player_id: c for c in changes}
+        # Equal ELO, expected = 0.5; actual winner = 1.0; delta = K * (1 - 0.5) = 16
+        assert by_id["p1"].delta == 16
+        assert by_id["p2"].delta == -16
+        assert by_id["p1"].elo_after == 1016
+        assert by_id["p2"].elo_after == 984
+
+    def test_deltas_sum_to_zero_two_players(self):
+        game = _game([_player("p1", 50), _player("p2", 30)])
+        changes = calculate_elo_changes(game, {"p1": 1200, "p2": 900})
+
+        assert sum(c.delta for c in changes) == 0
+
+    def test_three_players_ranking(self):
+        game = _game([_player("p1", 60), _player("p2", 40), _player("p3", 20)])
+        changes = calculate_elo_changes(game, {"p1": 1000, "p2": 1000, "p3": 1000})
+
+        by_id = {c.player_id: c for c in changes}
+        # p1 wins both pairwise comparisons; p3 loses both; p2 wins one and loses one.
+        assert by_id["p1"].delta > 0
+        assert by_id["p2"].delta == 0
+        assert by_id["p3"].delta < 0
+        # Sum should be ~0 (rounding may cause +/- 1)
+        assert abs(sum(c.delta for c in changes)) <= 1
+
+    def test_tied_game_gives_zero_delta(self):
+        # Both players with identical scores -> tied -> delta 0 with equal ELO
+        game = _game([_player("p1", 40), _player("p2", 40)])
+        changes = calculate_elo_changes(game, {"p1": 1000, "p2": 1000})
+
+        for c in changes:
+            assert c.delta == 0
+            assert c.elo_after == c.elo_before
+
+    def test_underdog_winner_gets_more_delta(self):
+        # p1 (1200) vs p2 (1000), p2 wins. p2 gains more than p1 would have gained
+        # by winning at equal ELO (16).
+        game = _game([_player("p2", 60), _player("p1", 30)])
+        changes = calculate_elo_changes(game, {"p1": 1200, "p2": 1000})
+
+        by_id = {c.player_id: c for c in changes}
+        assert by_id["p2"].delta > 16
+        assert by_id["p1"].delta < -16
+
+    def test_elo_before_matches_input(self):
+        game = _game([_player("p1", 50), _player("p2", 30)])
+        changes = calculate_elo_changes(game, {"p1": 1234, "p2": 987})
+
+        by_id = {c.player_id: c for c in changes}
+        assert by_id["p1"].elo_before == 1234
+        assert by_id["p2"].elo_before == 987
+
+    def test_K_factor_is_32(self):
+        # Sanity: the constant the algorithm rests on
+        assert K_FACTOR == 32


### PR DESCRIPTION
Sistema de Rating ELO Multijugador
Descripción
Implementa un sistema de ELO para partidas multijugador en Terraforming Mars. El ELO se calcula mediante comparaciones pairwise entre todos los jugadores de una partida, con K=32 y rating inicial de 1000.

Cambios principales
Base de datos

Nueva columna elo en players (default 1000)
Nueva tabla player_elo_history para persistir los cambios de ELO por partida
Lógica de negocio

ELO se recalcula al crear una partida
ELO se revierte y recalcula al actualizar una partida
ELO se revierte al eliminar una partida
Script seed_elo.py para backfill idempotente de partidas existentes en orden cronológico
API

GET /games/{game_id}/elo — retorna lista de EloChangeDTO con los cambios por jugador
POST /games/ — la respuesta ahora incluye elo_changes
Endpoints de jugadores (lista y perfil) exponen el ELO actual
Refactor

Lógica de mapeo de ELO extraída a elo_mapper.py
Criterios de verificación
 Rating inicial correcto (1000) para nuevos jugadores
 ELO se actualiza correctamente al crear una partida
 ELO se revierte y recalcula correctamente al editar una partida
 ELO se revierte al eliminar una partida
 Seed script funciona de forma idempotente sobre partidas existentes