### PR TITLE
chore: add Claude Code skills for scaffolding tasks

### DIFF
--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: new-component
+description: Scaffold a React component with TypeScript, CSS Module, and test file following project conventions
+argument-hint: [ComponentName]
+---
+
+# New React Component Scaffold
+
+Generate a complete React component for `$ARGUMENTS`.
+
+## Pre-flight
+
+1. Ask the user for:
+   - **Component name** (if not provided): PascalCase (e.g. `PlayerCard`)
+   - **Location**: `components/` (reusable) or `pages/` (route page)
+   - **Props**: name and type for each prop
+   - **State needs**: what local state it manages
+   - **Behavior**: what it does on interaction
+
+2. Confirm the plan before generating.
+
+## Files to generate
+
+### 1. Component — `frontend/src/{location}/{Name}/{Name}.tsx`
+
+```
+- Functional component with hooks
+- Interface `{Name}Props` extending native HTML props if applicable
+- Variant/size union types for styling when relevant
+- CSS Modules import: `import styles from './{Name}.module.css'`
+- className composition: array.filter(Boolean).join(' ')
+- Error/loading states via useState
+- Async handlers with try/catch/finally pattern
+- Spread remaining props on root element
+```
+
+Reference patterns:
+- Reusable component: `frontend/src/components/Button/Button.tsx`
+- Page component: `frontend/src/pages/Players/Players.tsx`
+
+### 2. CSS Module — `frontend/src/{location}/{Name}/{Name}.module.css`
+
+```
+- Mobile-first styles
+- Use CSS variables from the project's design system
+- No inline styles (project rule)
+- Semantic class names matching component structure
+- Use flexbox/grid for layout
+- Responsive breakpoints if needed
+```
+
+Reference: `frontend/src/components/Button/Button.module.css`
+
+### 3. Test — `frontend/src/test/components/{Name}.test.tsx`
+
+```
+- Vitest + React Testing Library
+- `renderComponent()` helper wrapping providers (MemoryRouter, AuthProvider) as needed
+- `beforeEach` for state cleanup
+- Query by role/label (accessibility-first)
+- Test: renders correctly, handles user interaction, shows errors, loading states
+```
+
+Reference: `frontend/src/test/components/Login.test.tsx`
+
+## Conventions
+
+- Export default for the component
+- Named exports for sub-components if any
+- Props interface defined above the component
+- `useState` for local state, custom hooks for data fetching
+- Error pattern: `err instanceof Error ? err.message : 'Error'`
+- Loading pattern: `disabled={loading}` on interactive elements
+- No emojis unless explicitly requested
+- Spanish for user-facing text (this is a Spanish-language app)

--- a/.claude/skills/new-endpoint/SKILL.md
+++ b/.claude/skills/new-endpoint/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: new-endpoint
+description: Scaffold a complete backend REST endpoint with all layers (schema, model, ORM, repo, mapper, service, route, container, main.py registration)
+argument-hint: [resource-name]
+---
+
+# New Backend Endpoint Scaffold
+
+Generate a complete backend REST endpoint for the resource `$ARGUMENTS`.
+
+## Pre-flight
+
+1. Ask the user for:
+   - **Resource name** (if not provided as argument): singular, snake_case (e.g. `achievement`)
+   - **Fields**: name, type, nullable, default, validation rules
+   - **Operations needed**: which CRUD endpoints (default: all — create, list, get, update, delete)
+   - **Business rules**: any validation logic beyond field types
+
+2. Confirm the plan before generating code.
+
+## Files to create/modify
+
+Generate code following the exact patterns already in this codebase. Use existing files as reference:
+
+### 1. Schema (DTO) — `backend/schemas/{resource}.py`
+- Pydantic V2 BaseModel
+- Separate DTOs: `{Resource}CreateDTO`, `{Resource}UpdateDTO` (optional fields), `{Resource}ResponseDTO`
+- Use `Field()` for validation (min_length, ge, etc.)
+- Reference: `backend/schemas/player.py`
+
+### 2. Domain Model — `backend/models/{resource}.py`
+- Plain Python class with `__init__`
+- No business logic, no DB deps
+- `{resource}_id: Optional[str]` as first param
+- Reference: `backend/models/player.py`
+
+### 3. ORM Model — add to `backend/db/models.py`
+- SQLAlchemy model inheriting `Base`
+- `__tablename__` = plural snake_case
+- `id = Column(String, primary_key=True)`
+- Reference: existing models in `backend/db/models.py`
+
+### 4. Alembic Migration
+- Tell the user to run: `docker compose exec backend alembic revision --autogenerate -m "add {resources} table"`
+- Then: `make migrate`
+
+### 5. Repository — `backend/repositories/{resource}_repository.py`
+- Class: `{Resource}Repository`
+- Constructor: `__init__(self, session_factory=get_session)`
+- Methods: `create`, `get`, `get_all`, `update`, `delete`
+- `create` auto-generates UUID if missing
+- `get` raises `KeyError` if not found
+- Context manager pattern: `with self._session_factory() as session:`
+- Reference: `backend/repositories/player_repository.py`
+
+### 6. Mapper — `backend/mappers/{resource}_mapper.py`
+- Pure functions: `{resource}_dto_to_model()` and `{resource}_model_to_dto()`
+- Reference: `backend/mappers/game_mapper.py`
+
+### 7. Service — `backend/services/{resource}_service.py`
+- Class: `{Resource}Service`
+- Constructor takes repository dependency
+- Public CRUD methods
+- Private `_validate_*()` methods for business rules
+- Raises `ValueError` for validation, `KeyError` for not found
+- Reference: `backend/services/player_service.py`
+
+### 8. Route — `backend/routes/{resources}_routes.py`
+- `APIRouter(prefix="/{resources}", tags=["{Resource}"])`
+- Exception handling: `KeyError` → 404, `ValueError` → 400
+- Response models on endpoints
+- Reference: `backend/routes/players_routes.py`
+
+### 9. Container — modify `backend/repositories/container.py`
+- Add: `from repositories.{resource}_repository import {Resource}Repository`
+- Add: `{resource}_repository = {Resource}Repository()`
+
+### 10. Main — modify `backend/main.py`
+- Add: `from routes.{resources}_routes import router as {resources}_router`
+- Add: `app.include_router({resources}_router)`
+
+## Important
+
+- All naming follows existing conventions (snake_case files, PascalCase classes)
+- DTOs use Pydantic V2 (BaseModel, Field)
+- Error handling pattern: try/except in routes, raise in services
+- UUIDs generated via `uuid4()` in repository
+- Session managed via context manager in repository
+- DO NOT run `pytest` on host — remind user to use `make test-backend`

--- a/.claude/skills/new-hook/SKILL.md
+++ b/.claude/skills/new-hook/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: new-hook
+description: Scaffold a custom React hook for data fetching with loading/error states and CRUD operations
+argument-hint: [resourceName]
+---
+
+# New Custom Hook Scaffold
+
+Generate a custom React hook for `$ARGUMENTS`.
+
+## Pre-flight
+
+1. Ask the user for:
+   - **Resource name** (if not provided): camelCase singular (e.g. `player`, `game`)
+   - **API module**: which file in `frontend/src/api/` to import from (or create new)
+   - **Operations**: which CRUD ops to expose (fetch, add, edit, delete)
+   - **Fetch params**: any filtering options (e.g. `activeOnly?: boolean`)
+
+2. Confirm before generating.
+
+## Files to generate
+
+### 1. Hook — `frontend/src/hooks/use{Resources}.ts`
+
+Follow this exact pattern from the codebase:
+
+```typescript
+import { useState, useEffect, useCallback } from 'react'
+import { get{Resources}, create{Resource}, update{Resource} } from '@/api/{resources}'
+import type { {Resource}ResponseDTO, {Resource}CreateDTO, {Resource}UpdateDTO } from '@/types'
+
+interface Use{Resources}Options {
+  // filtering params
+}
+
+export function use{Resources}(options: Use{Resources}Options = {}) {
+  const [{resources}, set{Resources}] = useState<{Resource}ResponseDTO[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetch{Resources} = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await get{Resources}(/* params from options */)
+      set{Resources}(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al cargar {resources}')
+    } finally {
+      setLoading(false)
+    }
+  }, [/* deps from options */])
+
+  useEffect(() => { fetch{Resources}() }, [fetch{Resources}])
+
+  const add{Resource} = useCallback(async (data: {Resource}CreateDTO): Promise<void> => {
+    await create{Resource}(data)
+    await fetch{Resources}()
+  }, [fetch{Resources}])
+
+  const edit{Resource} = useCallback(async (id: string, data: {Resource}UpdateDTO): Promise<void> => {
+    await update{Resource}(id, data)
+    await fetch{Resources}()
+  }, [fetch{Resources}])
+
+  return { {resources}, loading, error, refetch: fetch{Resources}, add{Resource}, edit{Resource} }
+}
+```
+
+Reference: `frontend/src/hooks/usePlayers.ts`, `frontend/src/hooks/useGames.ts`
+
+### 2. API Service (if needed) — `frontend/src/api/{resources}.ts`
+
+```typescript
+import { api } from './client'
+import type { {Resource}ResponseDTO, {Resource}CreateDTO } from '@/types'
+
+export function get{Resources}(): Promise<{Resource}ResponseDTO[]> {
+  return api.get<{Resource}ResponseDTO[]>('/{resources}/')
+}
+
+export function create{Resource}(data: {Resource}CreateDTO): Promise<{ id: string }> {
+  return api.post<{ id: string }>('/{resources}/', data)
+}
+
+// ... more as needed
+```
+
+Reference: `frontend/src/api/players.ts`
+
+### 3. Types (if needed) — add to `frontend/src/types/`
+
+- Interface for each DTO matching the backend schema
+- Export from types index if one exists
+
+## Conventions
+
+- Hook name: `use{Resources}` (plural)
+- Always return: `{ items, loading, error, refetch, ...mutations }`
+- `useCallback` on all async functions
+- `useEffect` triggers initial fetch
+- Mutations auto-refetch after success
+- Error messages in Spanish
+- No error handling in mutations (let it bubble to the component)

--- a/.claude/skills/new-record/SKILL.md
+++ b/.claude/skills/new-record/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: new-record
+description: Add a new record calculator to the Strategy pattern registry with proper base class, registration, and mapper support
+argument-hint: [record-name]
+---
+
+# New Record Calculator
+
+Add a new record to the records system for `$ARGUMENTS`.
+
+## Pre-flight
+
+1. Ask the user for:
+   - **Record name** (if not provided): snake_case code (e.g. `highest_venus_points`)
+   - **Description**: what this record tracks (Spanish, e.g. "Mayor puntaje de Venus en una partida")
+   - **Title**: achievement title (Spanish, e.g. "Conquistador de Venus")
+   - **Emoji**: representative emoji
+   - **Calculator type**:
+     - **MaxScore** — highest value from a player score field (use `MaxScoreCalculator`)
+     - **Accumulative** — aggregates across all games (like `MostGamesPlayedCalculator`)
+     - **Custom** — unique logic needing its own class
+
+2. Confirm before generating.
+
+## Architecture
+
+The records system uses a Strategy pattern:
+
+```
+base.py          → RecordCalculator (ABC) with calculate() and evaluate()
+max_score_calculator.py → MaxScoreCalculator (reusable for single-field max records)
+registry.py      → ALL_CALCULATORS list
+```
+
+## For MaxScore type (simplest)
+
+Create `backend/services/record_calculators/{record_name}.py`:
+
+```python
+from services.record_calculators.max_score_calculator import MaxScoreCalculator
+
+{RecordName}Calculator = MaxScoreCalculator(
+    extractor=lambda p: p.scores.{field_name},
+    code="{record_name}",
+    title="{title}",
+    emoji="{emoji}",
+    description="{description}"
+)
+```
+
+Reference: `backend/services/record_calculators/highest_city_points.py`
+
+## For Accumulative type
+
+Create `backend/services/record_calculators/{record_name}.py`:
+
+```python
+from typing import List
+from collections import Counter
+from models.game import Game
+from models.record_entry import RecordEntry, RecordAttribute, LABEL_PLAYER
+from services.record_calculators.base import RecordCalculator
+
+class {RecordName}Calculator(RecordCalculator):
+    code = "{record_name}"
+    description = "{description}"
+    title = "{title}"
+    emoji = "{emoji}"
+
+    def games_for_current(self, games_until_current):
+        return games_until_current  # Uses ALL games, not just last
+
+    def calculate(self, games: List[Game]) -> RecordEntry | None:
+        if not games:
+            return None
+        # ... accumulation logic
+        return RecordEntry(
+            value=...,
+            title=self.title,
+            attributes=[RecordAttribute(label=LABEL_PLAYER, value=player_id)],
+        )
+```
+
+Reference: `backend/services/record_calculators/most_games_played.py`
+
+## For Custom type
+
+Create class extending `RecordCalculator` with custom `calculate()`. Override `games_for_current()` if needed.
+
+## Registration
+
+Add to `backend/services/record_calculators/registry.py`:
+
+1. Import the calculator
+2. Add to `ALL_CALCULATORS` list
+
+## Important notes
+
+- `calculate()` receives a `List[Game]` and returns `RecordEntry | None`
+- `games_for_current()` defaults to last game only; override for accumulative records
+- `evaluate()` in base class handles before/after comparison automatically
+- `RecordEntry` has: `value` (numeric), `title` (optional str), `attributes` (list of label/value)
+- Available attributes: `LABEL_PLAYER`, `LABEL_DATE` from `models.record_entry`
+- Player scores accessible via `player_result.scores.{field}` — check `models/player_score.py` for available fields
+- DO NOT run tests on host — use `make test-backend`

--- a/.claude/skills/sync-enums/SKILL.md
+++ b/.claude/skills/sync-enums/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: sync-enums
+description: Compare backend Python enums with frontend TypeScript enums and report any mismatches
+allowed-tools: Read, Grep, Bash
+---
+
+# Sync Enums — Frontend/Backend Verification
+
+Compare enums between backend and frontend to detect desynchronization.
+
+## Files to compare
+
+- **Backend**: `backend/models/enums.py` (Python Enum classes)
+- **Frontend**: `frontend/src/constants/enums.ts` (TypeScript enums)
+
+## Enums to check
+
+| Backend Class | Frontend Enum |
+|--------------|---------------|
+| `MapName` | `MapName` |
+| `Expansion` | `Expansion` |
+| `Milestone` | `Milestone` |
+| `Award` | `Award` |
+| `Corporation` | `Corporation` |
+
+## Process
+
+1. Read both files
+2. For each enum, extract all key-value pairs from both sides
+3. Compare and report:
+   - **Missing in frontend**: keys present in backend but not in frontend
+   - **Missing in backend**: keys present in frontend but not in backend
+   - **Value mismatch**: same key but different string value
+   - **Order differences**: only note if significant (e.g. grouping by map/expansion changed)
+
+## Output format
+
+For each enum, report:
+
+```
+## {EnumName}: {OK | MISMATCH}
+
+{If MISMATCH:}
+- MISSING in frontend: KEY = "value"
+- MISSING in backend: KEY = "value"
+- VALUE MISMATCH: KEY → backend="X" vs frontend="Y"
+```
+
+## If mismatches found
+
+- Ask the user which direction to sync (backend → frontend is the default, since backend is the source of truth)
+- Apply the fix
+- Remind about the comment at the top of `enums.ts`: "Values must match backend string values exactly"
+
+## If all OK
+
+Report: "All enums synchronized. {N} enums checked, {M} total values."

--- a/.claude/skills/test-backend/SKILL.md
+++ b/.claude/skills/test-backend/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: test-backend
+description: Run backend pytest safely inside Docker (never on host — protects dev database)
+allowed-tools: Bash
+argument-hint: [optional: test path or -k filter]
+---
+
+# Run Backend Tests (Docker)
+
+Run backend tests safely using `docker-compose.test.yml`. NEVER run pytest directly on the host machine — it uses the dev database and will wipe data.
+
+## Execution
+
+### No arguments — run all tests:
+
+```bash
+make test-backend
+```
+
+This runs:
+1. `docker compose -f docker-compose.test.yml down` (clean state)
+2. `docker compose -f docker-compose.test.yml run --rm --build backend_test` (migrations + pytest)
+3. `docker compose -f docker-compose.test.yml down` (cleanup)
+
+### With arguments — run specific tests:
+
+If `$ARGUMENTS` is provided, run filtered tests:
+
+```bash
+docker compose -f docker-compose.test.yml down && \
+docker compose -f docker-compose.test.yml run --rm --build backend_test sh -c "alembic upgrade head && python -m pytest $ARGUMENTS -q" && \
+docker compose -f docker-compose.test.yml down
+```
+
+Examples:
+- `/test-backend tests/test_player_service.py` — run one file
+- `/test-backend -k test_create` — run by name pattern
+- `/test-backend tests/ -v` — verbose output
+- `/test-backend tests/ --tb=short` — short tracebacks
+
+## CRITICAL SAFETY RULE
+
+**NEVER** run any of these on the host:
+- `pytest`
+- `python -m pytest`
+- Any direct test invocation outside Docker
+
+The host's `DATABASE_URL` points to the dev database. Running pytest there **will delete all game data**.
+
+## On failure
+
+1. Show the failing test output
+2. Identify the root cause
+3. If it's a test environment issue (DB connection, migration), suggest rebuilding: `docker compose -f docker-compose.test.yml down -v` then retry
+4. If it's a code issue, fix and re-run


### PR DESCRIPTION
## Summary
- Add 6 SKILL.md definitions to \`.claude/skills/\` for common scaffolding/check tasks
- Skills: \`new-component\`, \`new-endpoint\`, \`new-hook\`, \`new-record\`, \`sync-enums\`, \`test-backend\`

## Test plan
- [ ] Verificar que los skills aparecen disponibles en sesiones nuevas de Claude Code
- [ ] Probar al menos uno (ej. \`/sync-enums\` o \`/test-backend\`) para confirmar que ejecuta como esperado

🤖 Generated with [Claude Code](https://claude.com/claude-code)