### PR TITLE
feat: manual Supabase DB backup workflow to Cloudflare R2

### DIFF
--- a/.github/workflows/backup-supabase.yml
+++ b/.github/workflows/backup-supabase.yml
@@ -1,0 +1,77 @@
+name: Backup Supabase to R2
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: "Optional suffix for the backup filename (e.g. pre-migration)"
+        required: false
+        default: ""
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install postgresql-client-15
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client-15
+          pg_dump --version
+
+      - name: Compute backup filename
+        id: name
+        run: |
+          TIMESTAMP=$(date -u +'%Y%m%d-%H%M%S')
+          LABEL="${{ inputs.label }}"
+          if [ -n "$LABEL" ]; then
+            SAFE_LABEL=$(echo "$LABEL" | tr -c '[:alnum:]-_' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
+            FILENAME="tm-scorekeeper-${TIMESTAMP}-${SAFE_LABEL}.sql.gz"
+          else
+            FILENAME="tm-scorekeeper-${TIMESTAMP}.sql.gz"
+          fi
+          echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
+          echo "Backup filename: $FILENAME"
+
+      - name: Dump database and compress
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          pg_dump \
+            --schema=public \
+            --no-owner \
+            --no-acl \
+            --format=plain \
+            "$DATABASE_URL" \
+            | gzip -9 > "${{ steps.name.outputs.filename }}"
+          ls -lh "${{ steps.name.outputs.filename }}"
+          gunzip -t "${{ steps.name.outputs.filename }}"
+
+      - name: Upload to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+        run: |
+          aws s3 cp \
+            "${{ steps.name.outputs.filename }}" \
+            "s3://${R2_BUCKET}/${{ steps.name.outputs.filename }}" \
+            --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+      - name: Verify upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+        run: |
+          aws s3 ls \
+            "s3://${R2_BUCKET}/${{ steps.name.outputs.filename }}" \
+            --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ make migrate
 
 ---
 
+## Operaciones
+
+- **Backups de la DB de producción** — workflow manual que dumpea Supabase a un bucket de Cloudflare R2. Ver [`docs/backups.md`](docs/backups.md).
+
+---
+
 ## Estructura del proyecto
 
 ```

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,134 @@
+# Backups de la base de datos
+
+Workflow manual para dumpear la DB Postgres de Supabase y persistir el archivo en un bucket de Cloudflare R2.
+
+Ubicación: [`.github/workflows/backup-supabase.yml`](../.github/workflows/backup-supabase.yml)
+
+---
+
+## Cuándo correrlo
+
+- **Antes de migraciones** que toquen schema o datos críticos.
+- **Antes de refactors** que cambien tablas o constraints.
+- **Periódicamente** (semanal/mensual) a criterio del owner — no hay schedule automático.
+
+---
+
+## Cómo dispararlo
+
+1. GitHub → repo → **Actions** → **Backup Supabase to R2**
+2. Botón **Run workflow** (esquina superior derecha)
+3. Elegir branch (cualquiera funciona — el workflow no depende del checkout, solo de los secrets)
+4. Opcional: `label` — sufijo descriptivo para el archivo (ej. `pre-migration-005`, `weekly`)
+5. **Run workflow**
+
+El job tarda ~30s–2min según el tamaño de la DB.
+
+---
+
+## Naming convention
+
+```
+tm-scorekeeper-<UTC-YYYYMMDD-HHMMSS>[-<label>].sql.gz
+```
+
+Ejemplos:
+- `tm-scorekeeper-20260426-143022.sql.gz`
+- `tm-scorekeeper-20260426-143022-pre-migration.sql.gz`
+
+Timestamp en UTC para ordenamiento lexicográfico estable.
+
+---
+
+## Cómo restaurar
+
+> ⚠️ **WARNING**: el dump contiene `DROP` implícito vía recreación de objetos. Ejecutar contra una DB de producción **sobreescribe** datos. Hacer SIEMPRE en una DB de prueba primero.
+
+### Restaurar a una DB local de prueba
+
+```bash
+# 1. Descargar el backup desde R2 (Cloudflare dashboard o aws CLI)
+aws s3 cp \
+  s3://tm-scorekeeper-backups/tm-scorekeeper-20260426-143022.sql.gz \
+  ./backup.sql.gz \
+  --endpoint-url https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+
+# 2. Verificar integridad
+gunzip -t backup.sql.gz
+
+# 3. Crear DB destino y restaurar
+createdb tm_restore_test
+gunzip -c backup.sql.gz | psql postgresql://localhost/tm_restore_test
+```
+
+### Restaurar a producción (último recurso)
+
+1. Confirmar que es necesario (data loss real, no un mistake reversible).
+2. Avisar a los usuarios — la restauración deja la DB inconsistente durante la operación.
+3. Restaurar primero en staging/dummy, validar.
+4. Coordinar ventana de mantenimiento.
+5. `gunzip -c backup.sql.gz | psql "$SUPABASE_DIRECT_URL"`
+
+---
+
+## Retención
+
+El workflow **no elimina backups antiguos**. La retención se configura en Cloudflare R2 con una **lifecycle rule**:
+
+1. Cloudflare dashboard → R2 → bucket → **Settings** → **Object lifecycle rules**
+2. Crear regla: por ejemplo, eliminar objetos con prefijo `tm-scorekeeper-` después de 90 días.
+
+Recomendación inicial: 90 días, ajustar según costo y compliance.
+
+---
+
+## Secrets requeridos en GitHub
+
+Configurar en: repo → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
+
+| Secret | Valor | Dónde se obtiene |
+|---|---|---|
+| `DATABASE_URL` | Connection string Postgres de Supabase (**direct**, ver caveat abajo) | Supabase dashboard → Project settings → Database → Connection string |
+| `CLOUDFLARE_R2_ACCOUNT_ID` | Account ID de Cloudflare | R2 dashboard → API (sidebar derecha) |
+| `CLOUDFLARE_R2_ACCESS_KEY_ID` | Access Key ID del API token | R2 → **Manage R2 API Tokens** → **Create API token** (scope: read/write al bucket) |
+| `CLOUDFLARE_R2_SECRET_ACCESS_KEY` | Secret Access Key del mismo token | Mismo token (solo se ve una vez al crear) |
+| `CLOUDFLARE_R2_BUCKET` | Nombre del bucket | El que hayas creado, ej. `tm-scorekeeper-backups` |
+
+`DATABASE_URL` ya existe (lo usa `deploy.yml` para correr migraciones). Verificar el caveat antes de reusar el mismo secret.
+
+---
+
+## Caveat: pooler vs direct connection
+
+Supabase expone dos endpoints para Postgres:
+
+| Tipo | Puerto | Sirve para |
+|---|---|---|
+| **Direct** | `5432` | `pg_dump`, sesiones largas, transacciones grandes |
+| **Pooler** (PgBouncer) | `6543` | Queries cortas en modo transaction pooling |
+
+**`pg_dump` falla contra el pooler** (PgBouncer transaction mode no soporta `COPY` ni sesiones que exceden una transacción).
+
+### Cómo verificar
+
+Mirar el host en `DATABASE_URL`:
+- Direct: `db.<PROJECT_REF>.supabase.co` — puerto `5432`
+- Pooler: `<region>.pooler.supabase.com` — puerto `6543` (o `5432` con `?pgbouncer=true`)
+
+### Si `DATABASE_URL` es el pooler
+
+El backend en Render probablemente usa el pooler (recomendado para apps web). En ese caso:
+
+1. Agregar un secret aparte `SUPABASE_DIRECT_URL` con la connection string del puerto `5432`.
+2. Editar `.github/workflows/backup-supabase.yml`: cambiar `${{ secrets.DATABASE_URL }}` → `${{ secrets.SUPABASE_DIRECT_URL }}` en el step **Dump database and compress**.
+
+---
+
+## Troubleshooting
+
+| Error | Causa | Fix |
+|---|---|---|
+| `pg_dump: error: query failed: ERROR: prepared statement "..." does not exist` | `DATABASE_URL` apunta al pooler | Usar direct connection (ver caveat) |
+| `An error occurred (NoSuchBucket)` | Bucket no existe o nombre incorrecto en `CLOUDFLARE_R2_BUCKET` | Verificar nombre exacto en R2 dashboard |
+| `An error occurred (InvalidAccessKeyId)` | Credenciales R2 inválidas o revocadas | Regenerar API token en R2 |
+| `pg_dump: error: server version: 16.x; pg_dump version: 15.x` | Supabase upgradeó Postgres | Actualizar `postgresql-client-15` → `-16` en el workflow |


### PR DESCRIPTION
## Summary

Primer mecanismo de backups del proyecto. Workflow manual (`workflow_dispatch`) que dumpea la DB Postgres de Supabase y la sube a un bucket de Cloudflare R2 vía la API S3-compatible.

- **Workflow**: `.github/workflows/backup-supabase.yml`
- **Docs**: `docs/backups.md` (uso, restore, retención, secrets, caveat pooler/direct, troubleshooting)
- **README**: link nuevo en sección "Operaciones"

### Diseño
- Trigger: solo `workflow_dispatch` (input opcional `label` para sufijo del archivo).
- `pg_dump --schema=public --no-owner --no-acl --format=plain` → `gzip -9` → `aws s3 cp` con `--endpoint-url https://<account>.r2.cloudflarestorage.com`.
- Reusa `secrets.DATABASE_URL`. Agrega 4 secrets nuevos: `CLOUDFLARE_R2_{ACCOUNT_ID,ACCESS_KEY_ID,SECRET_ACCESS_KEY,BUCKET}`.
- PG client version hardcodeada en 15 (matchea `deploy.yml` y `docker-compose.yml`).

### Out of scope (PRs futuros)
- Schedule automático (cron)
- Restore script
- Lifecycle/retención (se configura en R2 dashboard)
- Test-restore automatizado

## Acciones manuales antes de testear

1. Crear bucket R2 en Cloudflare (sugerido `tm-scorekeeper-backups`).
2. Generar API token R2 con read/write al bucket.
3. Configurar los 4 secrets en GitHub repo settings.
4. **Verificar que `DATABASE_URL` sea direct connection** (puerto 5432, host `db.<ref>.supabase.co`). Si Render usa el pooler, agregar `SUPABASE_DIRECT_URL` y editar el workflow para usarlo (ver caveat en `docs/backups.md`).

## Test plan

- [ ] YAML del workflow parsea OK (validado localmente).
- [ ] Configurar bucket R2 + secrets en GitHub.
- [ ] Confirmar que `DATABASE_URL` es direct connection (o agregar `SUPABASE_DIRECT_URL`).
- [ ] Disparar el workflow manualmente desde Actions → "Backup Supabase to R2" → Run workflow.
- [ ] Verificar en R2 dashboard que el archivo aparece y tiene tamaño > 0.
- [ ] Descargar y validar integridad: `gunzip -t backup.sql.gz`.
- [ ] (Opcional) Restaurar a una DB local de prueba con `gunzip -c backup.sql.gz | psql postgresql://localhost/test_restore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)