### PR TITLE
chore: bump local and CI postgres to 17 to match production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: tm_user
           POSTGRES_PASSWORD: tm_pass

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
   db_test:
-    image: postgres:15
+    image: postgres:17
     environment:
       POSTGRES_USER: tm_user
       POSTGRES_PASSWORD: tm_pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:15
+    image: postgres:17
     restart: always
     environment:
       POSTGRES_USER: tm_user


### PR DESCRIPTION
## Summary

Producción corre en Supabase Postgres 17.6. Local (`docker-compose.yml`, `docker-compose.test.yml`) y el job de CI (`deploy.yml`) seguían en `postgres:15`. Esto causa:

1. **Imposible restaurar dumps de prod en local** — `pg_dump 17` emite meta-commands de psql (`\\restrict`, `\\unrestrict`) que psql 15 no entiende.
2. **Tests de CI corren contra PG15 mientras prod corre PG17** — divergencia silenciosa, una migración PG-version-sensitive se nos pasaría sin que CI lo detecte.

Bump simple `postgres:15` → `postgres:17` en los 3 archivos.

## Test plan

- [ ] CI verde (los tests de backend deberían pasar contra PG17 sin cambios — SQLAlchemy + alembic son agnósticos de versión, y `psycopg2-binary` no está pinneado).
- [ ] Después de mergear, en local: `docker compose down -v && docker compose up -d db`. Volumen recreado limpio.
- [ ] Re-correr el backend container, verificar que el seed corre y los tests del backend pasan en local.

## Notas

- El volumen `db_data` se va a recrear desde cero en local — no es upgrade in-place. Es OK porque íbamos a sobreescribirlo con el restore del backup de prod igual.
- `psycopg2-binary` floats en `requirements.txt`, no requiere bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)