### PR TITLE
feat: make restore-prod target for local DB restoration from R2 backups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev down migrate logs test-backend test-frontend typechecks
+.PHONY: dev down migrate logs test-backend test-frontend typechecks restore-prod
 
 dev:
 	docker compose up --build
@@ -22,3 +22,22 @@ test-frontend:
 
 typechecks:
 	docker compose exec frontend npm run typecheck
+
+restore-prod:
+ifndef FILE
+	@echo "Usage: make restore-prod FILE=/path/to/backup.sql.gz"
+	@echo "Download the latest backup from Cloudflare R2 (bucket: tm-scorekeeper-backups)."
+	@exit 1
+endif
+	@test -f "$(FILE)" || { echo "ERROR: file not found: $(FILE)"; exit 1; }
+	@gunzip -t "$(FILE)" 2>/dev/null || { echo "ERROR: not a valid gzip file: $(FILE)"; exit 1; }
+	@gunzip -c "$(FILE)" | head -5 | grep -q "PostgreSQL database dump" || { echo "ERROR: file does not look like pg_dump output: $(FILE)"; exit 1; }
+	@printf "This will WIPE your local DB and restore from:\n  $(FILE)\nContinue? [y/N] "; read ans; [ "$$ans" = "y" ] || { echo "Aborted."; exit 1; }
+	docker compose down -v
+	docker compose up -d db
+	@echo "Waiting for db to be healthy..."
+	@until docker exec tm-scorekeeper-db-1 pg_isready -U tm_user -d tm_scorekeeper >/dev/null 2>&1; do sleep 1; done
+	docker exec tm-scorekeeper-db-1 psql -U tm_user -d tm_scorekeeper -v ON_ERROR_STOP=1 -c "DROP SCHEMA IF EXISTS public CASCADE;"
+	gunzip -c "$(FILE)" | docker exec -i tm-scorekeeper-db-1 psql -U tm_user -d tm_scorekeeper -v ON_ERROR_STOP=1
+	docker compose up -d
+	@echo "Restore complete. Stack running at http://localhost:5173"

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ make down
 ## Comandos disponibles
 
 ```bash
-make dev            # Levanta todos los servicios (hot-reload activo)
-make down           # Detiene y elimina los contenedores
-make migrate        # Aplica migraciones de base de datos (Alembic)
-make logs           # Tail de logs de todos los servicios
-make test-backend   # Corre los tests del backend (pytest)
-make test-frontend  # Corre los tests del frontend (vitest)
-make typechecks     # Typecheck de TypeScript (tsc -b)
+make dev                              # Levanta todos los servicios (hot-reload activo)
+make down                             # Detiene y elimina los contenedores
+make migrate                          # Aplica migraciones de base de datos (Alembic)
+make logs                             # Tail de logs de todos los servicios
+make test-backend                     # Corre los tests del backend (pytest)
+make test-frontend                    # Corre los tests del frontend (vitest)
+make typechecks                       # Typecheck de TypeScript (tsc -b)
+make restore-prod FILE=<backup.sql.gz>  # Restaura un backup de prod a la DB local (DESTRUCTIVO — pisa todo)
 ```
 
 ---

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -44,19 +44,31 @@ Timestamp en UTC para ordenamiento lexicográfico estable.
 
 > ⚠️ **WARNING**: el dump contiene `DROP` implícito vía recreación de objetos. Ejecutar contra una DB de producción **sobreescribe** datos. Hacer SIEMPRE en una DB de prueba primero.
 
-### Restaurar a una DB local de prueba
+### Restaurar a la DB local de desarrollo (camino fácil)
+
+Hay un target en el `Makefile` que automatiza todo el flujo (down -v → up db → drop schema → restore → up):
 
 ```bash
-# 1. Descargar el backup desde R2 (Cloudflare dashboard o aws CLI)
-aws s3 cp \
-  s3://tm-scorekeeper-backups/tm-scorekeeper-20260426-143022.sql.gz \
-  ./backup.sql.gz \
-  --endpoint-url https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+# 1. Bajar el backup desde Cloudflare R2 dashboard → bucket tm-scorekeeper-backups
+#    (Click en el archivo .sql.gz más reciente → Download)
 
-# 2. Verificar integridad
-gunzip -t backup.sql.gz
+# 2. Correr el restore (te pide confirmación antes de pisar la DB)
+make restore-prod FILE=/Users/facu/Downloads/tm-scorekeeper-20260427-XXXXXX.sql.gz
+```
 
-# 3. Crear DB destino y restaurar
+⚠️ Pisa toda la DB local. El target valida antes de hacer destructive ops:
+- File existe
+- Es un gzip válido
+- Contiene header de `pg_dump`
+- Pide confirmación interactiva `[y/N]`
+
+### Restaurar a una DB local de prueba (manual, sin pisar dev)
+
+Si querés restaurar en una DB aparte sin tocar tu dev local:
+
+```bash
+# Asumiendo que tenés psql 17+ local (brew install postgresql@17)
+gunzip -t backup.sql.gz                    # verificar integridad
 createdb tm_restore_test
 gunzip -c backup.sql.gz | psql postgresql://localhost/tm_restore_test
 ```


### PR DESCRIPTION
## Summary

Automatiza el flujo de restaurar un backup de prod en local detrás de un solo comando.

```
make restore-prod FILE=/path/to/backup.sql.gz
```

Encapsula los pasos manuales que veníamos haciendo: `compose down -v` → recreate volumen db → drop schema public → `gunzip | psql` → `compose up`.

### Validación pre-destrucción

Antes de tocar la DB, el target verifica:
- El archivo existe
- Es un gzip válido (`gunzip -t`)
- Contiene el header de `pg_dump` (`-- PostgreSQL database dump` en las primeras líneas)
- Confirmación interactiva `[y/N]`

Si cualquiera falla, sale antes de tocar nada. Un typo en el path no termina en DB pisada.

### Cambios

- `Makefile` — target `restore-prod` (`.PHONY` actualizado)
- `README.md` — agregada la línea en la tabla de comandos
- `docs/backups.md` — la sección "Restaurar a DB local" ahora muestra el flujo con `make` como camino default; el método manual queda como alternativa para restaurar a una DB aparte sin tocar dev

## Test plan

- [x] `make restore-prod` (sin FILE) → printea usage y exit 1 ✅
- [x] `make restore-prod FILE=/nonexistent` → "ERROR: file not found" y exit 1 ✅
- [ ] `make restore-prod FILE=<archivo válido>` → pide confirmación, ejecuta el flow completo, stack levantado al final (pendiente — el último restore lo hicimos manual; siguiente backup que descargue Facu lo prueba con el target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)