### PR TITLE
v1.0 cleanup: phase 5 — close audit gaps INT-01 / INT-02 / FLOW-01

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Milestones
 
-- v1.0 Sistema de Logros — Phases 1-4 (shipped 2026-04-01)
+- v1.0 Sistema de Logros — Phases 1-4 (shipped 2026-04-01) + Cleanup Phases 5-7 (post-ship)
 
 ## Phases
 
@@ -16,6 +16,45 @@
 
 </details>
 
+### v1.0 Cleanup (post-ship) — closes gaps from `v1.0-MILESTONE-AUDIT.md`
+
+- [ ] **Phase 5: Cleanup integración v1.0** — closes INT-01 (high), INT-02 (medium), FLOW-01
+- [ ] **Phase 6: Drifts y polish v1.0** — clears low-severity drifts named in audit §8 / §10
+- [ ] **Phase 7: Documentación y proceso v1.0** — reconciles docs with shipped code (12 evaluators) and standardizes SUMMARY frontmatter
+
+#### Phase 5: Cleanup integración v1.0
+**Goal:** Restore documented architectural patterns (singleton `AchievementsService` + retry-once on achievement triggers) so v1.0 ships clean against project rules
+**Depends on:** Nothing (independent cleanup of existing v1.0 code)
+**Requirements:** INTG-03 (architectural), TOOL-02 (architectural), ENDG-01 (retry behavior)
+**Gap Closure:** INT-01, INT-02, FLOW-01
+**Success Criteria:**
+  1. `services/container.py` exposes `achievements_service` as a singleton; `games_routes`, `players_routes`, `achievements_routes` import it (no local instantiation)
+  2. `GameRecords.tsx` calls `useGames.fetchAchievements` (retry-once preserved); no direct `triggerAchievements` + bare `.catch(() => {})` anywhere
+  3. All 131+ existing tests still pass
+**Plans:** TBD via `/gsd-plan-phase 5`
+
+#### Phase 6: Drifts y polish v1.0
+**Goal:** Eliminate dead/misleading code surface area flagged as low-severity drifts
+**Depends on:** Nothing
+**Requirements:** API-03 (DTO consistency), ENDG-02/ENDG-03 (badge props), PROF-02 (card props)
+**Gap Closure:** Audit tech_debt items — `AchievementCatalogItemDTO.title` mapper drift, `AchievementBadgeMini.is_upgrade` unused prop, `AchievementCard.max_tier` unused prop, cosmetic blank-line cleanup in `games_routes.py`
+**Success Criteria:**
+  1. `AchievementCatalogItemDTO.title` carries a value distinct from `description` (or the field is removed from DTO + frontend usage)
+  2. `AchievementBadgeMini` and `AchievementCard` declare only props they actually consume; parent components stop passing the removed props
+  3. Backend lint/format clean on `games_routes.py`
+**Plans:** TBD via `/gsd-plan-phase 6`
+
+#### Phase 7: Documentación y proceso v1.0
+**Goal:** Bring shipped documentation in sync with shipped code and standardize plan SUMMARY frontmatter
+**Depends on:** Nothing
+**Requirements:** None (process/documentation phase)
+**Gap Closure:** Audit cross-cutting tech_debt — evaluator count drift (5 documented vs 12 shipped) and SUMMARY frontmatter inconsistency (only 2 of 8 SUMMARYs carry standardized requirements list)
+**Success Criteria:**
+  1. `MILESTONES.md`, Phase 01 SUMMARY, and `RETROSPECTIVE.md` accurately list the 12 evaluators registered in `registry.py`
+  2. All 8 v1.0 plan SUMMARYs carry `requirements` / `requirements-completed` frontmatter
+  3. Audit re-run shows zero `tech_debt` items in the doc/process category
+**Plans:** TBD via `/gsd-plan-phase 7`
+
 ## Progress
 
 | Phase | Milestone | Plans Complete | Status | Completed |
@@ -24,3 +63,6 @@
 | 2. Integración y API | v1.0 | 2/2 | Complete | 2026-03-31 |
 | 3. Frontend | v1.0 | 3/3 | Complete | 2026-04-01 |
 | 4. Reconciliador | v1.0 | 1/1 | Complete | 2026-04-01 |
+| 5. Cleanup integración | v1.0 cleanup | 0/? | Pending | — |
+| 6. Drifts y polish | v1.0 cleanup | 0/? | Pending | — |
+| 7. Documentación y proceso | v1.0 cleanup | 0/? | Pending | — |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -31,7 +31,9 @@
   1. `services/container.py` exposes `achievements_service` as a singleton; `games_routes`, `players_routes`, `achievements_routes` import it (no local instantiation)
   2. `GameRecords.tsx` calls `useGames.fetchAchievements` (retry-once preserved); no direct `triggerAchievements` + bare `.catch(() => {})` anywhere
   3. All 131+ existing tests still pass
-**Plans:** TBD via `/gsd-plan-phase 5`
+**Plans:** 2 plans
+- [ ] 05-01-PLAN.md — Backend: AchievementsService singleton en services/container.py + 3 routers refactorizados (cierra INT-01)
+- [ ] 05-02-PLAN.md — Frontend: GameRecords.tsx consume useGames.fetchAchievements (cierra INT-02 / FLOW-01)
 
 #### Phase 6: Drifts y polish v1.0
 **Goal:** Eliminate dead/misleading code surface area flagged as low-severity drifts

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -32,8 +32,8 @@
   2. `GameRecords.tsx` calls `useGames.fetchAchievements` (retry-once preserved); no direct `triggerAchievements` + bare `.catch(() => {})` anywhere
   3. All 131+ existing tests still pass
 **Plans:** 2 plans
-- [ ] 05-01-PLAN.md — Backend: AchievementsService singleton en services/container.py + 3 routers refactorizados (cierra INT-01)
-- [ ] 05-02-PLAN.md — Frontend: GameRecords.tsx consume useGames.fetchAchievements (cierra INT-02 / FLOW-01)
+- [x] 05-01-PLAN.md — Backend: AchievementsService singleton en services/container.py + 3 routers refactorizados (cierra INT-01)
+- [x] 05-02-PLAN.md — Frontend: GameRecords.tsx consume useGames.fetchAchievements (cierra INT-02 / FLOW-01)
 
 #### Phase 6: Drifts y polish v1.0
 **Goal:** Eliminate dead/misleading code surface area flagged as low-severity drifts

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,17 +1,17 @@
 ---
 gsd_state_version: 1.0
 milestone: v1.0
-milestone_name: milestone
-status: completed
+milestone_name: Cleanup
+status: executing
 stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-04-02T02:10:06.486Z"
-last_activity: 2026-04-02
+last_updated: "2026-04-28T00:02:09.283Z"
+last_activity: 2026-04-28 -- Phase 05 execution started
 progress:
-  total_phases: 4
-  completed_phases: 4
-  total_plans: 8
-  completed_plans: 8
-  percent: 100
+  total_phases: 3
+  completed_phases: 0
+  total_plans: 2
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-21)
 
 **Core value:** Los jugadores descubren y desbloquean logros al jugar, dándole más profundidad y motivación a cada partida. Los logros son permanentes.
-**Current focus:** Phase 04 — reconciliador
+**Current focus:** Phase 05 — cleanup-integracion
 
 ## Current Position
 
-Phase: 04
-Plan: Not started
-Status: All phases complete
-Last activity: 2026-04-02
+Phase: 05 (cleanup-integracion) — EXECUTING
+Plan: 1 of 2
+Status: Executing Phase 05
+Last activity: 2026-04-28 -- Phase 05 execution started
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.0
 milestone_name: Cleanup
 status: executing
 stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-04-28T00:02:09.283Z"
-last_activity: 2026-04-28 -- Phase 05 execution started
+last_updated: "2026-04-28T03:43:58.471Z"
+last_activity: 2026-04-28
 progress:
   total_phases: 3
-  completed_phases: 0
+  completed_phases: 1
   total_plans: 2
-  completed_plans: 0
-  percent: 0
+  completed_plans: 2
+  percent: 100
 ---
 
 # Project State
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 
 ## Current Position
 
-Phase: 05 (cleanup-integracion) — EXECUTING
-Plan: 1 of 2
+Phase: 06
+Plan: Not started
 Status: Executing Phase 05
-Last activity: 2026-04-28 -- Phase 05 execution started
+Last activity: 2026-04-28
 
 Progress: [██████████] 100%
 
@@ -36,7 +36,7 @@ Progress: [██████████] 100%
 
 **Velocity:**
 
-- Total plans completed: 0
+- Total plans completed: 2
 - Average duration: —
 - Total execution time: 0 hours
 
@@ -44,7 +44,7 @@ Progress: [██████████] 100%
 
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
-| - | - | - | - |
+| 05 | 2 | - | - |
 
 **Recent Trend:**
 

--- a/.planning/v1.0-MILESTONE-AUDIT.md
+++ b/.planning/v1.0-MILESTONE-AUDIT.md
@@ -1,0 +1,313 @@
+---
+milestone: v1.0
+milestone_name: Sistema de Logros
+audited: 2026-04-27T00:00:00Z
+audit_type: retroactive
+status: tech_debt
+scores:
+  requirements: 35/35
+  phases: 4/4
+  integration: 9/12
+  flows: 3/4
+phases:
+  - phase: 01-backend-core
+    verification: passed
+    score: 12/12
+    nyquist: PARTIAL
+  - phase: 02-integraci-n-y-api
+    verification: passed
+    score: 11/11
+    nyquist: PARTIAL
+  - phase: 03-frontend
+    verification: passed
+    score: 12/12
+    nyquist: PARTIAL
+  - phase: 04-reconciliador
+    verification: passed
+    score: 5/5
+    nyquist: PARTIAL
+gaps:
+  requirements: []
+  integration:
+    - id: INT-01-container-pattern
+      severity: high
+      finding: "AchievementsService is not a singleton in services/container.py — instantiated 3x across routes (games_routes.py:36-40, players_routes.py:30-34, achievements_routes.py:8-12). services/container.py only contains elo_service."
+      affected_reqs: [INTG-03, TOOL-02]
+      affected_files:
+        - backend/services/container.py
+        - backend/routes/achievements_routes.py
+        - backend/routes/games_routes.py
+        - backend/routes/players_routes.py
+      runtime_impact: none
+      pattern_violated: feedback_container_per_layer
+    - id: INT-02-orphan-retry-contract
+      severity: medium
+      finding: "useGames.fetchAchievements is exported with retry-once logic (useGames.ts:83) but no caller. GameRecords.tsx:46 calls triggerAchievements directly with a bare .catch(() => {}), bypassing the retry contract documented in Phase 2."
+      affected_reqs: [ENDG-01]
+      affected_files:
+        - frontend/src/hooks/useGames.ts
+        - frontend/src/pages/GameRecords/GameRecords.tsx
+  flows:
+    - id: FLOW-01-retry-bypass
+      flow: "Game submission → achievements unlock"
+      severity: medium
+      breaks_at: "GameRecords.tsx:46 — direct triggerAchievements call instead of useGames.fetchAchievements"
+      runtime_impact: "Retry-once on transient network failure is missing; first failure surfaces silently"
+tech_debt:
+  - phase: 02-integraci-n-y-api
+    items:
+      - "DRIFT: AchievementCatalogItemDTO.title is set to definition.description in mappers/achievement_mapper.py:82 — both DTO fields carry the same value. Frontend has adapted by rendering description, leaving title as redundant/misleading."
+      - "Anti-pattern (info): double blank lines in games_routes.py (cosmetic only)."
+      - "Human verification deferred (2 items): E2E achievement trigger cycle against real DB; frontend retry behavior under throttled network."
+  - phase: 03-frontend
+    items:
+      - "DRIFT: AchievementBadgeMini declares is_upgrade prop (AchievementBadgeMini.tsx:9) but never reads it in the component body — only is_new is used. Visual differentiation works because is_new is the inverse signal."
+      - "DRIFT: AchievementCard accepts max_tier in props interface (AchievementCard.tsx:10), passed from PlayerProfile.tsx:165, but is not destructured/used inside the component."
+      - "Human verification deferred (4 items): Logros tab lazy-load behavior; post-game modal rendering; catalog holders modal; new-vs-upgrade border colors."
+  - phase: cross-cutting
+    items:
+      - "DOC DRIFT: Phase 01 SUMMARY and project docs reference 5 evaluators (high_score, games_played, games_won, win_streak, all_maps). registry.py:107-119 actually registers 12: also greenery_tiles, milestone_master, no_milestone_win, award_master, no_award_win, stolen_awards, card_points. SUMMARY/MILESTONES docs under-count what shipped."
+      - "Process: SUMMARY frontmatter inconsistent — only 2 of 8 SUMMARYs (01-02, 02-02) carry the standardized requirements/requirements-completed list. The other 6 require manual cross-reference against VERIFICATION.md tables. Retrospective already flagged this."
+      - "REQUIREMENTS.md traceability not auto-updated when phases completed — explicitly called out in RETROSPECTIVE.md as inefficiency."
+nyquist:
+  enabled: true
+  compliant_phases: 0
+  partial_phases: 4
+  missing_phases: 0
+  overall: PARTIAL
+  detail:
+    - phase: 01-backend-core
+      validation_md: present
+      nyquist_compliant: false
+      wave_0_complete: false
+      action: "/gsd-validate-phase 01"
+    - phase: 02-integraci-n-y-api
+      validation_md: present
+      nyquist_compliant: false
+      wave_0_complete: false
+      action: "/gsd-validate-phase 02"
+    - phase: 03-frontend
+      validation_md: present
+      nyquist_compliant: false
+      wave_0_complete: false
+      action: "/gsd-validate-phase 03"
+    - phase: 04-reconciliador
+      validation_md: present
+      nyquist_compliant: false
+      wave_0_complete: false
+      action: "/gsd-validate-phase 04"
+human_verification_deferred:
+  total: 6
+  by_phase:
+    "02-integraci-n-y-api": 2
+    "03-frontend": 4
+deviations_documented:
+  - id: INTG-01
+    requirement_text: "Evaluación post-commit en create_game()"
+    actual_implementation: "Separate POST /games/{id}/achievements endpoint, frontend chains the call after createGame()"
+    authority: "CONTEXT.md decision D-01 (Phase 02) overrides REQUIREMENTS.md literal text"
+    status: satisfied_with_deviation
+  - id: ICON-02
+    requirement_text: "Integración vite-plugin-svgr para SVG como componentes React"
+    actual_implementation: "Lucide-react fallback chain — SVG custom layer deferred to v2"
+    authority: "REQUIREMENTS.md marks Complete (adjusted); v2 backlog item VIS-01"
+    status: satisfied_with_scope_adjustment
+---
+
+# v1.0 Sistema de Logros — Milestone Audit (Retroactive)
+
+**Audited:** 2026-04-27 · **Audit type:** Retroactive (milestone shipped 2026-04-01 without prior audit)
+**Final status:** `tech_debt` — all 35 requirements satisfied, no blocking gaps, but accumulated tech debt and pattern drifts require attention before the next milestone.
+
+---
+
+## 1. Summary
+
+| Dimension | Score | Status |
+|-----------|-------|--------|
+| Requirements coverage | 35/35 | All v1 reqs satisfied (2 documented deviations) |
+| Phases verified | 4/4 | All `passed`, scores 12/12, 11/11, 12/12, 5/5 |
+| Cross-phase integration | 9/12 wires | 1 high-severity pattern violation, 1 medium-severity contract bypass, 3 low-severity drifts |
+| End-to-end flows | 3/4 fully wired | Flow 1 (game→unlock) has the retry-bypass tech debt; functions correctly without retries |
+| Nyquist compliance | 0/4 phases compliant | All 4 phases PARTIAL — `wave_0_complete: false` across the board |
+| Human verification deferred | 6 checks | 2 from Phase 02, 4 from Phase 03 |
+
+The milestone delivers what was promised at the user-visible level. The issues are pattern violations and contract drifts that don't fail tests but represent real architectural debt against this project's documented conventions.
+
+---
+
+## 2. Phase Verifications
+
+| Phase | VERIFICATION.md | Plans | Score | Critical Gaps | Notes |
+|-------|-----------------|-------|-------|---------------|-------|
+| 01-backend-core | passed (2026-03-31) | 2/2 | 12/12 | none | Clean. No anti-patterns. No human verification needed. |
+| 02-integraci-n-y-api | passed (2026-03-31) | 2/2 | 11/11 | none | INTG-01 deviation documented; 2 deferred human checks; 2 cosmetic anti-patterns. |
+| 03-frontend | passed (2026-04-01) | 3/3 | 12/12 | none | ICON-02 deferred to v2 by design; 4 deferred human checks. |
+| 04-reconciliador | passed (2026-04-01) | 1/1 | 5/5 | none | Clean. compute_tier-not-evaluate decision validated. |
+
+All four phases pass on their own terms. Issues surface only when checking integration across phases.
+
+---
+
+## 3. Requirements Coverage (35/35)
+
+All 35 v1 requirements are satisfied per the 3-source cross-reference (REQUIREMENTS.md traceability + VERIFICATION.md tables + SUMMARY frontmatter or VERIFICATION evidence where SUMMARY frontmatter is missing).
+
+### Documented Deviations (Satisfied With Deviation)
+
+| REQ-ID | Original Text | What Actually Shipped | Authority |
+|--------|---------------|------------------------|-----------|
+| INTG-01 | Evaluación post-commit en `create_game()` (inline) | Separate `POST /games/{id}/achievements` endpoint; frontend chains call after `createGame()` | CONTEXT.md D-01 (Phase 02) — explicit override |
+| ICON-02 | Integración vite-plugin-svgr | Lucide-react fallback chain; custom SVG layer deferred to v2 (VIS-01) | REQUIREMENTS.md note "Complete (adjusted)" |
+
+Both deviations are intentional, documented, and acknowledged by REQUIREMENTS.md / CONTEXT.md. They are not unsatisfied requirements.
+
+### Process Gap: SUMMARY Frontmatter
+
+Only 2 of 8 plan SUMMARYs (`01-02-SUMMARY.md`, `02-02-SUMMARY.md`) carry the standardized `requirements`/`requirements-completed` list. The other 6 SUMMARYs lack this metadata, forcing fallback to VERIFICATION.md tables to map plans → REQ-IDs. This was already called out in `RETROSPECTIVE.md` ("REQUIREMENTS.md traceability wasn't auto-updated when phases completed"). It is a process drift, not a coverage gap — the implementations exist and are verified.
+
+---
+
+## 4. Cross-Phase Integration Findings
+
+### High Severity
+
+#### INT-01 — `AchievementsService` not in `services/container.py`
+
+The project memory `feedback_container_per_layer` mandates that services live as singletons in `services/container.py`. `services/container.py` only contains `elo_service`. `AchievementsService` is instead instantiated three independent times — once per router file:
+
+- `backend/routes/games_routes.py:36-40`
+- `backend/routes/players_routes.py:30-34`
+- `backend/routes/achievements_routes.py:8-12`
+
+All three constructors pass the same repository singletons from `repositories/container.py`, so no runtime divergence occurs today. But the pattern is wrong, will cause drift the moment any service-level state is introduced (caching, metrics, request-scoped data), and contradicts an explicit project rule.
+
+**Affected reqs:** INTG-03 (functional ✓; architectural ✗), TOOL-02 (functional ✓; architectural ✗)
+**Remediation:** Add `achievements_service = AchievementsService(...)` to `services/container.py`; rewrite the three router files to import from there; delete the three local instantiations.
+
+### Medium Severity
+
+#### INT-02 — Retry-once contract orphaned
+
+Phase 02 SUMMARY documents that `useGames.fetchAchievements` (`useGames.ts:83-96`) implements retry-once-on-failure as the integration point for post-game achievement triggers. The hook exposes it at line 98.
+
+`GameRecords.tsx:46` instead calls `triggerAchievements(gameId)` directly with `.catch(() => {})`. `GameForm.tsx` uses `useGames` only for `submitGame` and never calls `fetchAchievements`.
+
+Net effect: `useGames.fetchAchievements` is dead code. Transient network failures during achievement evaluation are not retried — the first failure surfaces as a silent no-op with no console warning, no retry, no user signal.
+
+**Affected reqs:** ENDG-01 (post-game modal still appears when call succeeds; degraded behavior on failure).
+**Remediation:** Either (a) refactor `GameRecords.tsx` to consume `useGames.fetchAchievements`, restoring the documented retry contract, or (b) explicitly remove `fetchAchievements` from `useGames.ts` and update Phase 02 SUMMARY to reflect the actual call site.
+
+### Low Severity (Drifts)
+
+| Drift | Location | Impact |
+|-------|----------|--------|
+| `AchievementCatalogItemDTO.title` carries `definition.description` (both fields equal) | `backend/mappers/achievement_mapper.py:82`, `backend/models/achievement_definition.py` (no `title` field on definition) | Frontend renders `.description`; `.title` is redundant. Future consumer expecting a distinct human title gets the description string. |
+| `AchievementBadgeMini.is_upgrade` prop declared and passed, never read | `frontend/src/components/AchievementBadgeMini/AchievementBadgeMini.tsx:9,17` | Visual differentiation still works (driven by `is_new`); prop is structural noise. |
+| `AchievementCard.max_tier` prop in interface and passed by parent, not destructured in component | `frontend/src/components/AchievementCard/AchievementCard.tsx:10`, `PlayerProfile.tsx:165` | "Max tier" indicator silently absent at runtime. |
+
+### Information
+
+- **Evaluator count drift.** Phase 01 SUMMARY, `MILESTONES.md`, and `RETROSPECTIVE.md` all reference 5 evaluators (`high_score`, `games_played`, `games_won`, `win_streak`, `all_maps`). The actual `ALL_EVALUATORS` registry in `backend/services/achievement_evaluators/registry.py:107-119` registers **12**: the original 5 plus `greenery_tiles`, `milestone_master`, `no_milestone_win`, `award_master`, `no_award_win`, `stolen_awards`, `card_points`. The extras presumably shipped between v1.0 and now. Documentation should be updated, but this is not a milestone defect — the requirement was "at least 3 evaluators covering the three condition types" (CORE-08) which is more than satisfied.
+
+---
+
+## 5. End-to-End Flow Verification
+
+| # | Flow | Status |
+|---|------|--------|
+| 1 | Game submission → achievements unlock → modal | **WIRED with degradation.** Modal renders correctly on success; retry-once on failure is bypassed (INT-02). |
+| 2 | Player profile → Logros tab → AchievementCards | **WIRED.** Lazy-load on tab activation, cards render with locked/unlocked states + progress. |
+| 3 | Achievement catalog → holders modal | **WIRED.** Catalog renders; click holder opens modal with name/tier/date. (Title field carries description per DRIFT, not user-visible.) |
+| 4 | `POST /achievements/reconcile` (admin/batch) | **WIRED.** No frontend caller, expected per spec. `compute_tier`-not-`evaluate` decision validated; per-player error isolation works. |
+
+### No-Downgrade Invariant — Three-Layer Defense
+
+| Layer | Mechanism | File | Status |
+|-------|-----------|------|--------|
+| DB | `WHERE tier < excluded.tier` on `pg_insert.on_conflict_do_update` | `achievement_repository.py:29` | WIRED |
+| Reconciler | `if computed < current_tier: continue` | `achievements_service.py:150-156` | WIRED |
+| Evaluator | `evaluate()` returns `new_tier=None` when `computed <= persisted_tier` | `achievement_evaluators/base.py:33-40` | WIRED |
+
+All three layers are independently enforcing. The permanence guarantee survives concurrent writes, reconciliation, and incremental evaluation.
+
+---
+
+## 6. Nyquist Compliance Discovery
+
+| Phase | VALIDATION.md | `nyquist_compliant` | `wave_0_complete` | Classification |
+|-------|---------------|----------------------|-------------------|----------------|
+| 01-backend-core | present | false | false | **PARTIAL** |
+| 02-integraci-n-y-api | present | false | false | **PARTIAL** |
+| 03-frontend | present | false | false | **PARTIAL** |
+| 04-reconciliador | present | false | false | **PARTIAL** |
+
+All 4 phases have a draft VALIDATION.md but none are Nyquist-compliant. Tests exist (131+ across backend pytest + frontend vitest, all passing) but the per-phase Nyquist sampling contract was never formally completed. This is a **discovery only** finding — the audit does not auto-trigger validation runs.
+
+To remediate per phase: `/gsd-validate-phase 01`, `02`, `03`, `04`.
+
+---
+
+## 7. Human Verification Deferred (6 checks)
+
+These were marked in phase VERIFICATION frontmatter as requiring runtime/visual confirmation that automated checks cannot provide.
+
+**Phase 02 (2 checks):**
+1. End-to-end achievement trigger cycle against a real PostgreSQL DB.
+2. Frontend `useGames` retry behavior under simulated network throttling. (Note: this check is now moot due to **INT-02** — the retry path is no longer reachable from the UI.)
+
+**Phase 03 (4 checks):**
+3. Logros tab lazy-load timing and unlocked-first sort order.
+4. Post-game `AchievementModal` actually rendering after a real game registration.
+5. Catalog holders modal content and date formatting.
+6. New (accent border) vs. upgrade (success border) visual differentiation in `AchievementBadgeMini`.
+
+---
+
+## 8. Tech Debt — By Phase
+
+### Phase 02 — integración y api
+- **DRIFT:** `AchievementCatalogItemDTO.title` = `description` (mapper bug).
+- Cosmetic: double blank lines in `games_routes.py`.
+- Deferred human checks: 2.
+
+### Phase 03 — frontend
+- **DRIFT:** Unused `is_upgrade` prop in `AchievementBadgeMini`.
+- **DRIFT:** Unused `max_tier` prop in `AchievementCard`.
+- Deferred human checks: 4.
+
+### Cross-cutting
+- **HIGH:** `AchievementsService` missing from `services/container.py` (pattern violation).
+- **MEDIUM:** `useGames.fetchAchievements` orphaned; `GameRecords` bypasses retry contract.
+- **DOC:** Evaluator count documented as 5; actual is 12.
+- **PROCESS:** Only 2/8 SUMMARYs have standardized requirements frontmatter.
+- **PROCESS:** REQUIREMENTS.md traceability not auto-updated post-phase (already in retrospective).
+
+**Total: 7 tech debt items + 6 deferred human verifications + 4 partial-Nyquist phases.**
+
+---
+
+## 9. Verdict
+
+**`tech_debt`** — every requirement is met at the user-visible level, every E2E flow works, no test is failing. But the milestone shipped with:
+
+1. A direct violation of an explicit project pattern rule (container per layer).
+2. A documented integration contract (retry-once) that is no longer wired.
+3. Three low-severity prop/field drifts that should be cleaned up.
+4. Zero phases at Nyquist compliance.
+5. Six deferred human verifications never closed out.
+
+None of these block continuing to the records-ui milestone. All of them deserve a single cleanup phase before the next milestone ships, to prevent the patterns from compounding.
+
+---
+
+## 10. Recommended Next Steps
+
+1. `/gsd-plan-milestone-gaps` to plan a v1.0-cleanup phase covering INT-01, INT-02, the 3 drifts, and doc updates.
+2. `/gsd-validate-phase 01`, `02`, `03`, `04` (in parallel or sequentially) to close Nyquist gaps if Nyquist coverage is required for v1.0 archive.
+3. Resolve the 6 human verification checks (especially the post-game modal end-to-end on real data).
+4. Update `MILESTONES.md` and Phase 01 SUMMARY/RETROSPECTIVE to reflect the actual 12-evaluator registry.
+
+Or, if accepting the tech debt:
+
+- `/gsd-complete-milestone v1.0` — track items in backlog and proceed.

--- a/backend/routes/achievements_routes.py
+++ b/backend/routes/achievements_routes.py
@@ -1,15 +1,8 @@
 from fastapi import APIRouter
-from services.achievements_service import AchievementsService
+from services.container import achievements_service
 from schemas.achievement import AchievementCatalogResponseDTO, ReconcileResponseDTO, PlayerReconcileChangeDTO
-from repositories.container import games_repository, achievement_repository, players_repository
 
 router = APIRouter(prefix="/achievements", tags=["Achievements"])
-
-achievements_service = AchievementsService(
-    games_repository=games_repository,
-    achievement_repository=achievement_repository,
-    players_repository=players_repository,
-)
 
 
 @router.get("/catalog", response_model=AchievementCatalogResponseDTO)

--- a/backend/routes/games_routes.py
+++ b/backend/routes/games_routes.py
@@ -12,12 +12,10 @@ from schemas.result import GameResultDTO
 from repositories.container import (
     games_repository,
     players_repository,
-    achievement_repository,
     elo_repository,
 )
-from services.container import elo_service
+from services.container import achievements_service, elo_service
 from repositories.game_filters import GameFilter
-from services.achievements_service import AchievementsService
 from schemas.achievement import AchievementsByPlayerResponseDTO
 
 
@@ -31,12 +29,6 @@ games_service = GamesService(
     games_repository=games_repository,
     players_repository=players_repository,
     elo_service=elo_service,
-)
-
-achievements_service = AchievementsService(
-    games_repository=games_repository,
-    achievement_repository=achievement_repository,
-    players_repository=players_repository,
 )
 
 

--- a/backend/routes/players_routes.py
+++ b/backend/routes/players_routes.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, HTTPException, Query
 from schemas.player_profile import PlayerProfileDTO
 from services.player_profile_service import PlayerProfileService
-from repositories.container import games_repository, players_repository, achievement_repository
+from repositories.container import games_repository, players_repository
 from services.player_records_service import PlayerRecordsService
 from schemas.player import PlayerCreateDTO, PlayerCreatedResponseDTO, PlayerResponseDTO, PlayerUpdateDTO
 from services.player_service import PlayerService
+from services.container import achievements_service
 from typing import Optional
-from services.achievements_service import AchievementsService
 from schemas.achievement import PlayerAchievementsResponseDTO
 
 router = APIRouter(
@@ -25,12 +25,6 @@ player_profile_service = PlayerProfileService(
     players_repository=players_repository,
     games_repository=games_repository,
     player_records_service=player_records_service,
-)
-
-achievements_service = AchievementsService(
-    games_repository=games_repository,
-    achievement_repository=achievement_repository,
-    players_repository=players_repository,
 )
 
 

--- a/backend/services/container.py
+++ b/backend/services/container.py
@@ -5,10 +5,12 @@ service singletons from this module. Repositories never live here.
 """
 
 from repositories.container import (
+    achievement_repository,
     elo_repository,
     games_repository,
     players_repository,
 )
+from services.achievements_service import AchievementsService
 from services.elo_service import EloService
 
 
@@ -16,4 +18,10 @@ elo_service = EloService(
     elo_repository=elo_repository,
     players_repository=players_repository,
     games_repository=games_repository,
+)
+
+achievements_service = AchievementsService(
+    games_repository=games_repository,
+    achievement_repository=achievement_repository,
+    players_repository=players_repository,
 )

--- a/frontend/src/pages/GameRecords/GameRecords.tsx
+++ b/frontend/src/pages/GameRecords/GameRecords.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getGameRecords, getGameResults } from '@/api/games'
 import { getPlayers } from '@/api/players'
-import { triggerAchievements } from '@/api/achievements'
 import { ApiError } from '@/api/client'
+import { useGames } from '@/hooks/useGames'
 import Button from '@/components/Button/Button'
 import Spinner from '@/components/Spinner/Spinner'
 import RecordsSection from '@/components/RecordsSection/RecordsSection'
@@ -23,6 +23,7 @@ export default function GameRecords() {
   const [notAvailable, setNotAvailable] = useState(false)
   const [achievements, setAchievements] = useState<AchievementsByPlayerDTO | null>(null)
   const [showAchievementModal, setShowAchievementModal] = useState(false)
+  const { fetchAchievements } = useGames()
 
   useEffect(() => {
     if (!gameId) return
@@ -43,15 +44,14 @@ export default function GameRecords() {
       .then(setPlayers)
       .catch(() => {})
 
-    triggerAchievements(gameId)
-      .then(data => {
-        const hasAny = Object.values(data.achievements_by_player).some(list => list.length > 0)
-        if (hasAny) {
-          setAchievements(data)
-          setShowAchievementModal(true)
-        }
-      })
-      .catch(() => {})   // silent failure — achievements are non-critical
+    fetchAchievements(gameId).then(data => {
+      if (!data) return
+      const hasAny = Object.values(data.achievements_by_player).some(list => list.length > 0)
+      if (hasAny) {
+        setAchievements(data)
+        setShowAchievementModal(true)
+      }
+    })
   }, [gameId])
 
   const playersMap = new Map(players.map((p) => [p.player_id, p.name]))

--- a/frontend/src/test/components/GameRecords.test.tsx
+++ b/frontend/src/test/components/GameRecords.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import GameRecords from '@/pages/GameRecords/GameRecords'
+import type {
+  AchievementsByPlayerDTO,
+  GameResultDTO,
+  PlayerResponseDTO,
+  RecordComparisonDTO,
+} from '@/types'
+
+vi.mock('@/api/games', () => ({
+  getGameRecords: vi.fn(),
+  getGameResults: vi.fn(),
+}))
+vi.mock('@/api/players', () => ({
+  getPlayers: vi.fn(),
+}))
+vi.mock('@/api/achievements', () => ({
+  triggerAchievements: vi.fn(),
+}))
+
+import { getGameRecords, getGameResults } from '@/api/games'
+import { getPlayers } from '@/api/players'
+import { triggerAchievements } from '@/api/achievements'
+
+const mockGetGameRecords = vi.mocked(getGameRecords)
+const mockGetGameResults = vi.mocked(getGameResults)
+const mockGetPlayers = vi.mocked(getPlayers)
+const mockTriggerAchievements = vi.mocked(triggerAchievements)
+
+const PLAYERS: PlayerResponseDTO[] = [
+  { player_id: 'p1', name: 'Alice', is_active: true },
+  { player_id: 'p2', name: 'Bob', is_active: true },
+]
+
+const RECORDS: RecordComparisonDTO[] = []
+
+const RESULT: GameResultDTO = {
+  game_id: 'game-123',
+  date: '2026-04-01',
+  results: [
+    { player_id: 'p1', total_points: 95, mc_total: 80, position: 1, tied: false },
+    { player_id: 'p2', total_points: 70, mc_total: 50, position: 2, tied: false },
+  ],
+}
+
+const ACHIEVEMENTS_WITH_UNLOCKS: AchievementsByPlayerDTO = {
+  achievements_by_player: {
+    p1: [
+      { code: 'high_score', title: 'Alcanzar X puntos', tier: 1, is_new: true, is_upgrade: false, icon: null, fallback_icon: 'trophy' },
+    ],
+    p2: [],
+  },
+}
+
+const ACHIEVEMENTS_EMPTY: AchievementsByPlayerDTO = {
+  achievements_by_player: { p1: [], p2: [] },
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/games/game-123/records']}>
+      <Routes>
+        <Route path="/games/:gameId/records" element={<GameRecords />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+const RETRY_WARN_MSG = 'Failed to load achievements after retry'
+
+describe('GameRecords — achievements modal integration with useGames retry', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  function retryWarnCalls() {
+    return warnSpy.mock.calls.filter((args) => args[0] === RETRY_WARN_MSG)
+  }
+
+  beforeEach(() => {
+    mockGetGameRecords.mockReset().mockResolvedValue(RECORDS)
+    mockGetGameResults.mockReset().mockResolvedValue(RESULT)
+    mockGetPlayers.mockReset().mockResolvedValue(PLAYERS)
+    mockTriggerAchievements.mockReset()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('shows AchievementModal when there are unlocks (Caso A — happy path)', async () => {
+    mockTriggerAchievements.mockResolvedValueOnce(ACHIEVEMENTS_WITH_UNLOCKS)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Alcanzar X puntos')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /continuar/i })).toBeInTheDocument()
+    expect(mockTriggerAchievements).toHaveBeenCalledTimes(1)
+    expect(retryWarnCalls()).toHaveLength(0)
+  })
+
+  it('shows modal when first call fails and second succeeds (Caso B — retry exitoso)', async () => {
+    mockTriggerAchievements
+      .mockRejectedValueOnce(new Error('transient network error'))
+      .mockResolvedValueOnce(ACHIEVEMENTS_WITH_UNLOCKS)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Alcanzar X puntos')).toBeInTheDocument()
+    })
+    expect(mockTriggerAchievements).toHaveBeenCalledTimes(2)
+    expect(retryWarnCalls()).toHaveLength(0)
+  })
+
+  it('does NOT show modal when both retries fail (Caso C — retry agotado)', async () => {
+    mockTriggerAchievements
+      .mockRejectedValueOnce(new Error('offline 1'))
+      .mockRejectedValueOnce(new Error('offline 2'))
+    renderPage()
+
+    // Wait for the page to settle (records section renders)
+    await waitFor(() => {
+      expect(screen.getByText(/records/i)).toBeInTheDocument()
+    })
+    // Give the retry chain time to complete (microtask drain)
+    await waitFor(() => {
+      expect(mockTriggerAchievements).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.queryByRole('button', { name: /continuar/i })).not.toBeInTheDocument()
+    expect(retryWarnCalls()).toHaveLength(1)
+  })
+
+  it('does NOT show modal when achievements_by_player has only empty lists (Caso D — sin regresión)', async () => {
+    mockTriggerAchievements.mockResolvedValueOnce(ACHIEVEMENTS_EMPTY)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/records/i)).toBeInTheDocument()
+    })
+    // Confirm the achievements promise resolved
+    await waitFor(() => {
+      expect(mockTriggerAchievements).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.queryByRole('button', { name: /continuar/i })).not.toBeInTheDocument()
+    expect(retryWarnCalls()).toHaveLength(0)
+  })
+
+  it('renders the page without modal when triggerAchievements returns no unlocks and getPlayers fails silently', async () => {
+    mockGetPlayers.mockRejectedValueOnce(new Error('players unavailable'))
+    mockTriggerAchievements.mockResolvedValueOnce(ACHIEVEMENTS_EMPTY)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/¡partida guardada!/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: /continuar/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/hooks/useGames.test.ts
+++ b/frontend/src/test/hooks/useGames.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useGames } from '@/hooks/useGames'
+import { triggerAchievements } from '@/api/achievements'
+import type { AchievementsByPlayerDTO } from '@/types'
+
+vi.mock('@/api/achievements', () => ({
+  triggerAchievements: vi.fn(),
+}))
+
+const mockTriggerAchievements = vi.mocked(triggerAchievements)
+
+const SAMPLE_PAYLOAD: AchievementsByPlayerDTO = {
+  achievements_by_player: {
+    'p1': [
+      { code: 'high_score', title: 'Alcanzar X puntos', tier: 1, is_new: true, is_upgrade: false, icon: null, fallback_icon: 'trophy' },
+    ],
+  },
+}
+
+describe('useGames.fetchAchievements — retry contract (Phase 02 D-09/D-10)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockTriggerAchievements.mockReset()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('returns the payload on first success without retrying', async () => {
+    mockTriggerAchievements.mockResolvedValueOnce(SAMPLE_PAYLOAD)
+
+    const { result } = renderHook(() => useGames())
+
+    let value: AchievementsByPlayerDTO | null = null
+    await act(async () => {
+      value = await result.current.fetchAchievements('game-123')
+    })
+
+    expect(value).toEqual(SAMPLE_PAYLOAD)
+    expect(mockTriggerAchievements).toHaveBeenCalledTimes(1)
+    expect(mockTriggerAchievements).toHaveBeenCalledWith('game-123')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('retries once and returns the payload when the first call fails and the second succeeds (Caso B)', async () => {
+    mockTriggerAchievements
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(SAMPLE_PAYLOAD)
+
+    const { result } = renderHook(() => useGames())
+
+    let value: AchievementsByPlayerDTO | null = null
+    await act(async () => {
+      value = await result.current.fetchAchievements('game-123')
+    })
+
+    expect(value).toEqual(SAMPLE_PAYLOAD)
+    expect(mockTriggerAchievements).toHaveBeenCalledTimes(2)
+    expect(mockTriggerAchievements).toHaveBeenNthCalledWith(1, 'game-123')
+    expect(mockTriggerAchievements).toHaveBeenNthCalledWith(2, 'game-123')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null and warns exactly once when both attempts fail (Caso C)', async () => {
+    mockTriggerAchievements
+      .mockRejectedValueOnce(new Error('network down 1'))
+      .mockRejectedValueOnce(new Error('network down 2'))
+
+    const { result } = renderHook(() => useGames())
+
+    let value: AchievementsByPlayerDTO | null = null
+    await act(async () => {
+      value = await result.current.fetchAchievements('game-123')
+    })
+
+    expect(value).toBeNull()
+    expect(mockTriggerAchievements).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith('Failed to load achievements after retry')
+  })
+
+  it('does not retry more than once even if subsequent attempts would succeed', async () => {
+    mockTriggerAchievements
+      .mockRejectedValueOnce(new Error('1'))
+      .mockRejectedValueOnce(new Error('2'))
+      .mockResolvedValueOnce(SAMPLE_PAYLOAD)
+
+    const { result } = renderHook(() => useGames())
+
+    let value: AchievementsByPlayerDTO | null = null
+    await act(async () => {
+      value = await result.current.fetchAchievements('game-123')
+    })
+
+    expect(value).toBeNull()
+    expect(mockTriggerAchievements).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Closes the three architectural gaps flagged by `v1.0-MILESTONE-AUDIT.md` for v1.0 ship-readiness.

- **INT-01 (high)** — `AchievementsService` is now a singleton in `backend/services/container.py` (mirroring `elo_service`). The 3 routers (`games_routes`, `players_routes`, `achievements_routes`) consume it via `from services.container import achievements_service`; zero local instantiations remain.
- **INT-02 (medium) + FLOW-01 (medium)** — `GameRecords.tsx` no longer calls `triggerAchievements(...).catch(() => {})` directly. It now consumes `useGames().fetchAchievements`, restoring the Phase 02 D-09/D-10 retry-once-on-failure contract on the live UI path. `useGames.ts` and `api/achievements.ts` are unchanged (audit option `(a)`).
- **Coverage:** 9 new vitest cases (4 hook + 5 component integration) lock the retry contract — both retry-success and retry-exhausted paths are now observable in CI without DevTools throttling.

## Changes by surface

| Layer | What changed |
|------|--------------|
| Backend (4 files) | `services/container.py` exposes `achievements_service` singleton; 3 routers import it instead of instantiating locally. DI-only refactor — no behavior change. |
| Frontend (1 file) | `GameRecords.tsx` consumes `useGames().fetchAchievements`, expressing post-retry failure as `if (!data) return`. 10 insertions, 10 deletions. |
| Tests (2 new files) | `useGames.test.ts` (retry contract) + `GameRecords.test.tsx` (modal flow under all 4 audit-defined cases A/B/C/D). |
| Docs / planning | `ROADMAP.md` + `STATE.md` updated to reflect phase 5 complete; `v1.0-MILESTONE-AUDIT.md` checked in. |

## Test plan

- [x] `make test-backend` — 176/176 passed against the merged tree
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm test -- --run` — 16 files, 122/122 passed (was 113 pre-phase, +9 new)
- [x] End-to-end smoke: `POST /games/{id}/achievements` against the running backend returns 200 with valid `AchievementsByPlayerDTO` shape
- [x] Singleton identity check inside the running container: `container.achievements_service is games_routes.achievements_service is players_routes.achievements_service is achievements_routes.achievements_service` → True
- [ ] (optional) Manual browser verification of casos A/B/C/D under DevTools network throttling — equivalent to the 9 vitest cases, kept as belt-and-suspenders

## Notes

- Phase 5's `checkpoint:human-verify` gate was substituted by automated test coverage with explicit pre-approval. The substitution is documented in `05-02-SUMMARY.md` (not in this PR — see archived planning artifacts on `docs/v1.0-cleanup-phases`).
- A pre-existing dev-environment issue surfaced during verification: the local dev DB had not applied migration `b8d4e2c5a7f1, add elo system`. Resolved with `alembic upgrade head`. **Unrelated to this PR's code changes.**
- The "high"-severity gap (INT-01) and the two "medium" gaps (INT-02 / FLOW-01) are now closed. Phases 6 (drifts y polish) and 7 (docs y proceso) remain on the cleanup milestone.