### PR TITLE
v1.0 cleanup: phase 6 — drifts y polish (audit §8 tech_debt)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,7 +44,10 @@
   1. `AchievementCatalogItemDTO.title` carries a value distinct from `description` (or the field is removed from DTO + frontend usage)
   2. `AchievementBadgeMini` and `AchievementCard` declare only props they actually consume; parent components stop passing the removed props
   3. Backend lint/format clean on `games_routes.py`
-**Plans:** TBD via `/gsd-plan-phase 6`
+**Plans:** 3 plans
+- [ ] 06-01-PLAN.md — Eliminar `title` de `AchievementCatalogItemDTO` (backend schema + mapper + frontend type) — cierra drift API-03
+- [ ] 06-02-PLAN.md — Limpiar props muertos `AchievementBadgeMini.is_upgrade` y `AchievementCard.max_tier` (componentes + callers + tests) — cierra drifts ENDG-02/ENDG-03/PROF-02
+- [ ] 06-03-PLAN.md — Normalizar espaciado de líneas en blanco en `backend/routes/games_routes.py` (cleanup cosmético, sin formatter externo)
 
 #### Phase 7: Documentación y proceso v1.0
 **Goal:** Bring shipped documentation in sync with shipped code and standardize plan SUMMARY frontmatter
@@ -66,5 +69,5 @@
 | 3. Frontend | v1.0 | 3/3 | Complete | 2026-04-01 |
 | 4. Reconciliador | v1.0 | 1/1 | Complete | 2026-04-01 |
 | 5. Cleanup integración | v1.0 cleanup | 0/? | Pending | — |
-| 6. Drifts y polish | v1.0 cleanup | 0/? | Pending | — |
+| 6. Drifts y polish | v1.0 cleanup | 0/3 | Pending | — |
 | 7. Documentación y proceso | v1.0 cleanup | 0/? | Pending | — |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -45,9 +45,9 @@
   2. `AchievementBadgeMini` and `AchievementCard` declare only props they actually consume; parent components stop passing the removed props
   3. Backend lint/format clean on `games_routes.py`
 **Plans:** 3 plans
-- [ ] 06-01-PLAN.md — Eliminar `title` de `AchievementCatalogItemDTO` (backend schema + mapper + frontend type) — cierra drift API-03
-- [ ] 06-02-PLAN.md — Limpiar props muertos `AchievementBadgeMini.is_upgrade` y `AchievementCard.max_tier` (componentes + callers + tests) — cierra drifts ENDG-02/ENDG-03/PROF-02
-- [ ] 06-03-PLAN.md — Normalizar espaciado de líneas en blanco en `backend/routes/games_routes.py` (cleanup cosmético, sin formatter externo)
+- [x] 06-01-PLAN.md — Eliminar `title` de `AchievementCatalogItemDTO` (backend schema + mapper + frontend type) — cierra drift API-03
+- [x] 06-02-PLAN.md — Limpiar props muertos `AchievementBadgeMini.is_upgrade` y `AchievementCard.max_tier` (componentes + callers + tests) — cierra drifts ENDG-02/ENDG-03/PROF-02
+- [x] 06-03-PLAN.md — Normalizar espaciado de líneas en blanco en `backend/routes/games_routes.py` (cleanup cosmético, sin formatter externo)
 
 #### Phase 7: Documentación y proceso v1.0
 **Goal:** Bring shipped documentation in sync with shipped code and standardize plan SUMMARY frontmatter

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.0
 milestone_name: Cleanup
 status: executing
 stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-04-28T03:43:58.471Z"
-last_activity: 2026-04-28
+last_updated: "2026-04-28T14:57:44.406Z"
+last_activity: 2026-04-28 -- Phase 06 execution started
 progress:
   total_phases: 3
   completed_phases: 1
-  total_plans: 2
+  total_plans: 5
   completed_plans: 2
-  percent: 100
+  percent: 40
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-21)
 
 **Core value:** Los jugadores descubren y desbloquean logros al jugar, dándole más profundidad y motivación a cada partida. Los logros son permanentes.
-**Current focus:** Phase 05 — cleanup-integracion
+**Current focus:** Phase 06 — drifts-y-polish
 
 ## Current Position
 
-Phase: 06
-Plan: Not started
-Status: Executing Phase 05
-Last activity: 2026-04-28
+Phase: 06 (drifts-y-polish) — EXECUTING
+Plan: 1 of 3
+Status: Executing Phase 06
+Last activity: 2026-04-28 -- Phase 06 execution started
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.0
 milestone_name: Cleanup
 status: executing
 stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-04-28T14:57:44.406Z"
-last_activity: 2026-04-28 -- Phase 06 execution started
+last_updated: "2026-04-28T15:10:13.271Z"
+last_activity: 2026-04-28
 progress:
   total_phases: 3
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 5
-  completed_plans: 2
-  percent: 40
+  completed_plans: 5
+  percent: 100
 ---
 
 # Project State
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 
 ## Current Position
 
-Phase: 06 (drifts-y-polish) — EXECUTING
-Plan: 1 of 3
+Phase: 07
+Plan: Not started
 Status: Executing Phase 06
-Last activity: 2026-04-28 -- Phase 06 execution started
+Last activity: 2026-04-28
 
 Progress: [██████████] 100%
 
@@ -36,7 +36,7 @@ Progress: [██████████] 100%
 
 **Velocity:**
 
-- Total plans completed: 2
+- Total plans completed: 5
 - Average duration: —
 - Total execution time: 0 hours
 
@@ -45,6 +45,7 @@ Progress: [██████████] 100%
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
 | 05 | 2 | - | - |
+| 06 | 3 | - | - |
 
 **Recent Trend:**
 

--- a/backend/mappers/achievement_mapper.py
+++ b/backend/mappers/achievement_mapper.py
@@ -79,7 +79,6 @@ def build_catalog_item_dto(
     ]
     return AchievementCatalogItemDTO(
         code=evaluator.code,
-        title=evaluator.definition.description,
         description=evaluator.definition.description,
         icon=evaluator.definition.icon,
         fallback_icon=evaluator.definition.fallback_icon,

--- a/backend/routes/games_routes.py
+++ b/backend/routes/games_routes.py
@@ -19,7 +19,6 @@ from repositories.game_filters import GameFilter
 from schemas.achievement import AchievementsByPlayerResponseDTO
 
 
-
 router = APIRouter(
     prefix="/games",
     tags=["Games"]
@@ -45,12 +44,10 @@ def create_game(game: GameDTO):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-
 @router.get("/", response_model=list[GameDTO])
 def list_games(game_ids: Optional[list[str]] = Query(default=None)):
     filters = GameFilter(game_ids=set(game_ids)) if game_ids else None
     return games_service.list_games(filters)
-
 
 
 @router.get("/{game_id}/results", response_model=GameResultDTO)
@@ -61,7 +58,6 @@ def get_game_results(game_id: str):
         raise HTTPException(status_code=404, detail="Game not found")
 
 
-
 @router.put("/{game_id}")
 def update_game(game_id: str, game: GameDTO):
     try:
@@ -70,7 +66,6 @@ def update_game(game_id: str, game: GameDTO):
         raise HTTPException(status_code=404, detail="Game not found")
 
     return {"message": "Game updated successfully"}
-
 
 
 @router.delete("/{game_id}")

--- a/backend/schemas/achievement.py
+++ b/backend/schemas/achievement.py
@@ -54,7 +54,6 @@ class HolderDTO(BaseModel):
 
 class AchievementCatalogItemDTO(BaseModel):
     code: str
-    title: str
     description: str
     icon: Optional[str]
     fallback_icon: str

--- a/backend/tests/test_achievement_schemas.py
+++ b/backend/tests/test_achievement_schemas.py
@@ -159,7 +159,6 @@ class TestAchievementCatalogItemDTO:
         holder = HolderDTO(player_id="p1", player_name="Alice", tier=1, unlocked_at=date(2026, 1, 1))
         dto = AchievementCatalogItemDTO(
             code="high_score",
-            title="Colono",
             description="Score high",
             icon="trophy.svg",
             fallback_icon="trophy",

--- a/frontend/src/components/AchievementBadgeMini/AchievementBadgeMini.tsx
+++ b/frontend/src/components/AchievementBadgeMini/AchievementBadgeMini.tsx
@@ -6,7 +6,6 @@ interface AchievementBadgeMiniProps {
   tier: number
   fallback_icon: string
   is_new: boolean
-  is_upgrade: boolean
 }
 
 export default function AchievementBadgeMini({

--- a/frontend/src/components/AchievementCard/AchievementCard.tsx
+++ b/frontend/src/components/AchievementCard/AchievementCard.tsx
@@ -7,7 +7,6 @@ interface AchievementCardProps {
   description: string
   fallback_icon: string
   tier: number
-  max_tier: number
   unlocked: boolean
   progress: { current: number; target: number } | null
   onClick?: () => void

--- a/frontend/src/components/AchievementModal/AchievementModal.tsx
+++ b/frontend/src/components/AchievementModal/AchievementModal.tsx
@@ -26,7 +26,6 @@ export default function AchievementModal({ achievements, playerNames, onClose }:
                 tier={ach.tier}
                 fallback_icon={ach.fallback_icon}
                 is_new={ach.is_new}
-                is_upgrade={ach.is_upgrade}
               />
             ))}
           </div>

--- a/frontend/src/pages/PlayerProfile/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile/PlayerProfile.tsx
@@ -162,7 +162,6 @@ export default function PlayerProfile() {
                           description={ach.description}
                           fallback_icon={ach.fallback_icon}
                           tier={ach.tier}
-                          max_tier={ach.max_tier}
                           unlocked={ach.unlocked}
                           progress={ach.progress}
                         />

--- a/frontend/src/test/components/AchievementBadgeMini.test.tsx
+++ b/frontend/src/test/components/AchievementBadgeMini.test.tsx
@@ -7,7 +7,6 @@ const baseProps = {
   tier: 3,
   fallback_icon: 'trophy',
   is_new: true,
-  is_upgrade: false,
 }
 
 describe('AchievementBadgeMini', () => {
@@ -31,15 +30,15 @@ describe('AchievementBadgeMini', () => {
 
   it('uses data-type="new" when is_new=true', () => {
     const { container } = render(
-      <AchievementBadgeMini {...baseProps} is_new={true} is_upgrade={false} />,
+      <AchievementBadgeMini {...baseProps} is_new={true} />,
     )
     const badge = container.firstChild as HTMLElement
     expect(badge.getAttribute('data-type')).toBe('new')
   })
 
-  it('uses data-type="upgrade" when is_upgrade=true', () => {
+  it('uses data-type="upgrade" when is_new=false', () => {
     const { container } = render(
-      <AchievementBadgeMini {...baseProps} is_new={false} is_upgrade={true} />,
+      <AchievementBadgeMini {...baseProps} is_new={false} />,
     )
     const badge = container.firstChild as HTMLElement
     expect(badge.getAttribute('data-type')).toBe('upgrade')

--- a/frontend/src/test/components/AchievementCard.test.tsx
+++ b/frontend/src/test/components/AchievementCard.test.tsx
@@ -7,7 +7,6 @@ const baseProps = {
   description: 'Test description',
   fallback_icon: 'trophy',
   tier: 2,
-  max_tier: 5,
   unlocked: true,
   progress: null,
 }

--- a/frontend/src/test/components/AchievementCatalog.test.tsx
+++ b/frontend/src/test/components/AchievementCatalog.test.tsx
@@ -14,7 +14,6 @@ const mockCatalog = {
   achievements: [
     {
       code: 'high_score',
-      title: 'Gran Terraformador',
       description: 'Alcanzar X puntos en una partida',
       icon: null,
       fallback_icon: 'trophy',
@@ -30,7 +29,6 @@ const mockCatalog = {
     },
     {
       code: 'games_played',
-      title: 'Habitué',
       description: 'Jugar partidas',
       icon: null,
       fallback_icon: 'gamepad',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -199,7 +199,6 @@ export interface HolderDTO {
 
 export interface AchievementCatalogItemDTO {
   code: string
-  title: string
   description: string
   icon: string | null
   fallback_icon: string


### PR DESCRIPTION
## Summary

Closes the four cosmetic drifts flagged in `v1.0-MILESTONE-AUDIT.md` §8 (tech_debt). Pure dead-code / formatting cleanup — zero behavior change.

- **API-03 — `AchievementCatalogItemDTO.title` drift.** The mapper aliased `title = description` (same value in two fields, one of which the frontend never rendered). Removed `title` from `AchievementCatalogItemDTO` (backend schema + frontend type) and from `build_catalog_item_dto` in `mappers/achievement_mapper.py`. Per-tier titles still flow via `AchievementTierInfoDTO.title`.
- **ENDG-02 / ENDG-03 — `AchievementBadgeMini.is_upgrade` unused prop.** The component's `data-type` is derived from `is_new` only; `is_upgrade` was declared but never read. Removed from the prop interface and from `AchievementModal`'s passed props. Test \"data-type='upgrade' when is_upgrade=true\" reformulated to express the real rule (\"when is_new=false\").
- **PROF-02 — `AchievementCard.max_tier` unused prop.** Declared in props but never destructured/used. Removed from the interface and from `PlayerProfile`'s passed props.
- **Cosmetic — `games_routes.py` blank-line spacing.** Normalized triple-blank runs to PEP-8 double-blank between top-level defs. AST-equivalent before/after.

The transport DTOs `AchievementUnlockedDTO.is_upgrade` and `PlayerAchievementDTO.max_tier` stay intact — they're legitimate API response data, separate from the React-component prop drift that was cleaned.

## Changes by surface

| Layer | What changed |
|------|--------------|
| Backend (3 files) | `schemas/achievement.py` (drop `title`), `mappers/achievement_mapper.py` (drop `title=description` line), `routes/games_routes.py` (PEP-8 blank lines, semantically inert) |
| Frontend (5 files) | `types/index.ts` (drop `title` from catalog DTO), `components/AchievementBadgeMini/*.tsx` (drop `is_upgrade` prop), `components/AchievementCard/*.tsx` (drop `max_tier` prop), `components/AchievementModal/*.tsx` (stop passing `is_upgrade`), `pages/PlayerProfile/*.tsx` (stop passing `max_tier`) |
| Tests (3 files) | Updated 3 vitest fixtures + reformulated one assertion to match the real `data-type` rule. Backend test fixture in `test_achievement_schemas.py` updated. |
| Docs / planning | `ROADMAP.md` + `STATE.md` updated to reflect phase 6 complete. |

## Test plan

- [x] `make test-backend` — **176/176** passed against the merged tree
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm test -- --run` — **122/122** passed across 16 files
- [x] Code review (gsd-code-reviewer, standard depth): **clean** — 0 critical, 0 warning, 0 info
- [x] Phase verification (gsd-verifier): **passed** — 13/13 must-haves verified, all 4 requirement IDs (API-03, ENDG-02, ENDG-03, PROF-02) accounted for

## Notes

- Phase 6 plans were generated by `gsd-planner` straight from the audit's tech_debt section (no CONTEXT.md / RESEARCH.md needed — scope is fully specified by the audit).
- All three plans (06-01, 06-02, 06-03) ran in parallel via worktrees with zero `files_modified` overlap; all three produced atomic commits + SUMMARY.md.
- Cleanup milestone progress: 2/3 phases done (5 ✓, 6 ✓, 7 = docs y proceso, pending).