### PR TITLE
v1.0 cleanup: phase 7 — documentación y proceso

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -58,7 +58,9 @@
   1. `MILESTONES.md`, Phase 01 SUMMARY, and `RETROSPECTIVE.md` accurately list the 12 evaluators registered in `registry.py`
   2. All 8 v1.0 plan SUMMARYs carry `requirements` / `requirements-completed` frontmatter
   3. Audit re-run shows zero `tech_debt` items in the doc/process category
-**Plans:** TBD via `/gsd-plan-phase 7`
+**Plans:** 2 plans
+- [ ] 07-01-PLAN.md — Backfill `requirements:` / `requirements-completed:` frontmatter en las 8 SUMMARYs v1.0 + fix drift "5 → 12 evaluadores" en 01-02-SUMMARY y 02-02-SUMMARY (cierra DOC-DRIFT y PROCESS-summary-frontmatter)
+- [ ] 07-02-PLAN.md — Verificación read-only de `v1.0-REQUIREMENTS.md` Traceability (35/35 Complete) (cierra PROCESS-requirements-traceability)
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -59,8 +59,8 @@
   2. All 8 v1.0 plan SUMMARYs carry `requirements` / `requirements-completed` frontmatter
   3. Audit re-run shows zero `tech_debt` items in the doc/process category
 **Plans:** 2 plans
-- [ ] 07-01-PLAN.md — Backfill `requirements:` / `requirements-completed:` frontmatter en las 8 SUMMARYs v1.0 + fix drift "5 → 12 evaluadores" en 01-02-SUMMARY y 02-02-SUMMARY (cierra DOC-DRIFT y PROCESS-summary-frontmatter)
-- [ ] 07-02-PLAN.md — Verificación read-only de `v1.0-REQUIREMENTS.md` Traceability (35/35 Complete) (cierra PROCESS-requirements-traceability)
+- [x] 07-01-PLAN.md — Backfill `requirements:` / `requirements-completed:` frontmatter en las 8 SUMMARYs v1.0 + fix drift "5 → 12 evaluadores" en 01-02-SUMMARY y 02-02-SUMMARY (cierra DOC-DRIFT y PROCESS-summary-frontmatter)
+- [x] 07-02-PLAN.md — Verificación read-only de `v1.0-REQUIREMENTS.md` Traceability (35/35 Complete) (cierra PROCESS-requirements-traceability)
 
 ## Progress
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.0
 milestone_name: Cleanup
 status: executing
 stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-04-28T20:16:12.562Z"
-last_activity: 2026-04-28 -- Phase 07 execution started
+last_updated: "2026-04-28T20:21:49.712Z"
+last_activity: 2026-04-28
 progress:
   total_phases: 3
-  completed_phases: 2
+  completed_phases: 3
   total_plans: 7
-  completed_plans: 5
-  percent: 71
+  completed_plans: 7
+  percent: 100
 ---
 
 # Project State
@@ -25,10 +25,10 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 
 ## Current Position
 
-Phase: 07 (documentacion-y-proceso) — EXECUTING
-Plan: 1 of 2
+Phase: 07
+Plan: Not started
 Status: Executing Phase 07
-Last activity: 2026-04-28 -- Phase 07 execution started
+Last activity: 2026-04-28
 
 Progress: [██████████] 100%
 
@@ -36,7 +36,7 @@ Progress: [██████████] 100%
 
 **Velocity:**
 
-- Total plans completed: 5
+- Total plans completed: 7
 - Average duration: —
 - Total execution time: 0 hours
 
@@ -46,6 +46,7 @@ Progress: [██████████] 100%
 |-------|-------|-------|----------|
 | 05 | 2 | - | - |
 | 06 | 3 | - | - |
+| 07 | 2 | - | - |
 
 **Recent Trend:**
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.0
 milestone_name: Cleanup
 status: executing
 stopped_at: Completed 04-01-PLAN.md
-last_updated: "2026-04-28T15:10:13.271Z"
-last_activity: 2026-04-28
+last_updated: "2026-04-28T20:16:12.562Z"
+last_activity: 2026-04-28 -- Phase 07 execution started
 progress:
   total_phases: 3
   completed_phases: 2
-  total_plans: 5
+  total_plans: 7
   completed_plans: 5
-  percent: 100
+  percent: 71
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-21)
 
 **Core value:** Los jugadores descubren y desbloquean logros al jugar, dándole más profundidad y motivación a cada partida. Los logros son permanentes.
-**Current focus:** Phase 06 — drifts-y-polish
+**Current focus:** Phase 07 — documentacion-y-proceso
 
 ## Current Position
 
-Phase: 07
-Plan: Not started
-Status: Executing Phase 06
-Last activity: 2026-04-28
+Phase: 07 (documentacion-y-proceso) — EXECUTING
+Plan: 1 of 2
+Status: Executing Phase 07
+Last activity: 2026-04-28 -- Phase 07 execution started
 
 Progress: [██████████] 100%
 

--- a/.planning/milestones/v1.0-phases/01-backend-core/01-01-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/01-backend-core/01-01-SUMMARY.md
@@ -3,6 +3,8 @@ phase: 01-backend-core
 plan: 01
 subsystem: backend/persistence
 tags: [achievements, orm, repository, migration, tdd]
+requirements: [PERS-01, PERS-02, PERS-03, PERS-04]
+requirements-completed: [PERS-01, PERS-02, PERS-03, PERS-04]
 dependency_graph:
   requires: []
   provides: [PlayerAchievement ORM, AchievementRepository, domain models, Alembic migration]

--- a/.planning/milestones/v1.0-phases/01-backend-core/01-02-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/01-backend-core/01-02-SUMMARY.md
@@ -37,11 +37,12 @@ metrics:
   tasks_completed: 3
   files_created: 13
 requirements: [CORE-01, CORE-02, CORE-03, CORE-04, CORE-05, CORE-06, CORE-07, CORE-08]
+requirements-completed: [CORE-01, CORE-02, CORE-03, CORE-04, CORE-05, CORE-06, CORE-07, CORE-08]
 ---
 
 # Phase 01 Plan 02: Achievement Evaluators Summary
 
-Pure domain logic layer for the achievements system — AchievementEvaluator ABC, 2 generic evaluators, 2 custom evaluators, 5 achievement definitions, and the ALL_EVALUATORS registry.
+Pure domain logic layer for the achievements system — AchievementEvaluator ABC, 2 generic evaluators, 2 custom evaluators, 12 achievement definitions, and the ALL_EVALUATORS registry.
 
 ## What Was Built
 

--- a/.planning/milestones/v1.0-phases/02-integraci-n-y-api/02-01-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/02-integraci-n-y-api/02-01-SUMMARY.md
@@ -3,6 +3,8 @@ phase: 02-integraci-n-y-api
 plan: 01
 subsystem: backend-achievements-service
 tags: [service, dtos, mappers, repository, tdd]
+requirements: [API-03, INTG-01, INTG-02, INTG-04, INTG-05]
+requirements-completed: [API-03, INTG-01, INTG-02, INTG-04, INTG-05]
 dependency_graph:
   requires:
     - Phase 01 evaluator system (ALL_EVALUATORS, AchievementEvaluator base)

--- a/.planning/milestones/v1.0-phases/02-integraci-n-y-api/02-02-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/02-integraci-n-y-api/02-02-SUMMARY.md
@@ -11,8 +11,8 @@ requires:
 
 provides:
   - POST /games/{game_id}/achievements — triggers achievement evaluation, returns 200 with achievements_by_player (never 500)
-  - GET /players/{player_id}/achievements — returns all 5 achievements with tier/progress for player
-  - GET /achievements/catalog — returns all 5 achievement definitions with holders
+  - GET /players/{player_id}/achievements — returns all 12 achievements with tier/progress for player
+  - GET /achievements/catalog — returns all 12 achievement definitions with holders
   - achievements_router registered in main.py
   - TypeScript interfaces for all achievement DTOs in frontend/src/types/index.ts
   - frontend/src/api/achievements.ts with triggerAchievements, getPlayerAchievements, getAchievementsCatalog
@@ -52,6 +52,7 @@ patterns-established:
   - "Route files get a module-level service singleton, not inline instantiation per request"
   - "TypeScript interfaces mirror backend Pydantic schemas field-for-field"
 
+requirements: [INTG-03, API-01, API-02]
 requirements-completed: [INTG-03, API-01, API-02]
 
 # Metrics

--- a/.planning/milestones/v1.0-phases/03-frontend/03-01-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/03-frontend/03-01-SUMMARY.md
@@ -3,6 +3,8 @@ phase: 03-frontend
 plan: "01"
 subsystem: frontend-components
 tags: [react, components, achievements, lucide-react, css-modules, tdd]
+requirements: [ENDG-02, ENDG-03, PROF-02, PROF-03, PROF-04, ICON-01, ICON-02, ICON-03]
+requirements-completed: [ENDG-02, ENDG-03, PROF-02, PROF-03, PROF-04, ICON-01, ICON-02, ICON-03]
 dependency_graph:
   requires: []
   provides:

--- a/.planning/milestones/v1.0-phases/03-frontend/03-02-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/03-frontend/03-02-SUMMARY.md
@@ -3,6 +3,8 @@ phase: 03-frontend
 plan: "02"
 subsystem: frontend-integration
 tags: [react, achievements, tabs, modal, tdd, css-modules, typescript]
+requirements: [ENDG-01, PROF-01]
+requirements-completed: [ENDG-01, PROF-01]
 dependency_graph:
   requires:
     - 03-01 (TabBar, AchievementCard, AchievementBadgeMini components)

--- a/.planning/milestones/v1.0-phases/03-frontend/03-03-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/03-frontend/03-03-SUMMARY.md
@@ -3,6 +3,8 @@ phase: 03-frontend
 plan: 03
 subsystem: frontend
 tags: [react, achievements, catalog, modal, routing]
+requirements: [CATL-01, CATL-02]
+requirements-completed: [CATL-01, CATL-02]
 dependency_graph:
   requires: [03-01]
   provides: [AchievementCatalog page, /achievements route, Home nav link]

--- a/.planning/milestones/v1.0-phases/04-reconciliador/04-01-SUMMARY.md
+++ b/.planning/milestones/v1.0-phases/04-reconciliador/04-01-SUMMARY.md
@@ -3,6 +3,8 @@ phase: 04-reconciliador
 plan: "01"
 subsystem: backend
 tags: [achievements, reconciler, service, endpoint, tdd]
+requirements: [TOOL-01, TOOL-02, TOOL-03]
+requirements-completed: [TOOL-01, TOOL-02, TOOL-03]
 dependency_graph:
   requires:
     - backend/services/achievements_service.py (AchievementsService)


### PR DESCRIPTION
## Summary

Final phase of the v1.0 cleanup milestone. Closes the 3 cross-cutting `tech_debt` items from `v1.0-MILESTONE-AUDIT.md` §8. **Pure documentation work — zero code changes.**

- **DOC-DRIFT-evaluator-count.** `01-02-SUMMARY.md` claimed "5 achievement definitions" and `02-02-SUMMARY.md` claimed "all 5 achievements / definitions" — `registry.py` actually registers **12** (HIGH_SCORE, GAMES_PLAYED, GAMES_WON, WIN_STREAK, GREENERY_TILES, ALL_MAPS, MILESTONE_MASTER, NO_MILESTONE_WIN, AWARD_MASTER, NO_AWARD_WIN, STOLEN_AWARDS, CARD_POINTS). Three substring fixes (`5` → `12`) in those two files.
- **PROCESS-summary-frontmatter-inconsistent.** All 8 v1.0 plan SUMMARYs now carry top-level `requirements:` and `requirements-completed:` lists. Per-plan REQ assignment derived from each `*-PLAN.md` body and verified against the `v1.0-REQUIREMENTS.md` Traceability table — total 35 IDs across 8 plans = full v1.0 coverage.
- **PROCESS-requirements-traceability-not-auto-updated.** Read-only audit confirmed `v1.0-REQUIREMENTS.md` Traceability is at 35/35 Complete with 0 Pending. The audit's specific claim was historical and already resolved before this milestone began. Plan stamps that closure with reproducible evidence.

## Changes

| File | Change |
|------|--------|
| `01-01..04-01-SUMMARY.md` (8 files) | Top-level `requirements:` + `requirements-completed:` frontmatter backfilled |
| `01-02-SUMMARY.md` | 1 substring fix: `5 achievement definitions` → `12` |
| `02-02-SUMMARY.md` | 2 substring fixes: `all 5 achievement(s)/(definitions)` → `all 12 ...` |
| `ROADMAP.md` + `STATE.md` | Phase 7 marked complete |

## Test plan

- [x] All 8 v1.0 SUMMARYs grep-pass for top-level `requirements:` and `requirements-completed:`
- [x] `! grep -q "5 achievement definitions" 01-02-SUMMARY.md`
- [x] `! grep -q "all 5 achievement" 02-02-SUMMARY.md`
- [x] `v1.0-REQUIREMENTS.md` Traceability: TOTAL=35, CHECKED=35, UNCHECKED=0, COMPLETE=35, PENDING=0
- [x] Phase verifier: passed 8/8 must-haves

## Notes

- Per-plan REQ assignment:
  - 01-01 → PERS-01..04 · 01-02 → CORE-01..08 · 02-01 → API-03, INTG-01/02/04/05 · 02-02 → API-01/02, INTG-03 · 03-01 → ENDG-02/03, PROF-02/03/04, ICON-01/02/03 · 03-02 → ENDG-01, PROF-01 · 03-03 → CATL-01/02 · 04-01 → TOOL-01/02/03
- `MILESTONES.md` and `RETROSPECTIVE.md` were inspected for the same evaluator-count drift; neither contains a `5 evaluators` mention. RETROSPECTIVE.md correctly says "4 evaluator types" (referring to the strategy classes, not definition instances) — no edit needed.
- `03-03-SUMMARY.md:58` "All 5 AchievementCatalog tests pass" intentionally left as-is — it counts test cases at write time, not achievements.

## v1.0 cleanup milestone is now complete

| Phase | PR | Status |
|---|---|---|
| 5 — Cleanup integración (INT-01/INT-02/FLOW-01) | #55 | merged |
| 6 — Drifts y polish (audit §8 tech_debt) | #56 | merged |
| 7 — Documentación y proceso (cross-cutting) | (this PR) | open |

After merge, the v1.0 cleanup milestone closes with all audit gaps resolved.