### PR TITLE
Phase 8: backend GET /elo/history endpoint (ELO-API-01)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -12,12 +12,13 @@ Los jugadores descubren y desbloquean logros al jugar, dándole más profundidad
 
 **v1.0 shipped** — Sistema de Logros completo (2026-04-01)
 **v1.0 cleanup shipped** — gaps del audit cerrados (2026-04-28)
+**v1.1 Phase 8 shipped** — `GET /elo/history` endpoint live (2026-04-29) — backend listo para alimentar el chart de Ranking
 
 - Backend: 4 tipos de evaluadores (strategy pattern) registrando **12 definiciones** en `ALL_EVALUATORS`. `AchievementsService` centralizado como singleton en `services/container.py`.
 - Integración: evaluación automática post-partida, 3 endpoints REST
 - Frontend: badges en fin de partida con retry-once-on-failure observable; perfil con tabs (Stats/Records/Logros); catálogo global. Componentes limpios — sin props muertos.
 - Herramientas: reconciliador con garantía no-downgrade
-- Tests: 298 tests (122 frontend / 176 backend), todos en CI
+- Tests: 303 tests (122 frontend / 181 backend), todos en CI
 - Stack: FastAPI + SQLAlchemy + PostgreSQL 17 + Alembic / React 18 + TypeScript + Vite + CSS Modules
 
 ## Current Milestone: v1.1 Visualización de ELO en Frontend

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -66,7 +66,7 @@ Deferred — no entran en v1.1.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| ELO-API-01 | Phase 8 | In Progress |
+| ELO-API-01 | Phase 8 | Complete |
 | PROF-01 | Phase 9 | Pending |
 | PROF-02 | Phase 9 | Pending |
 | PROF-03 | Phase 9 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -66,7 +66,7 @@ Deferred — no entran en v1.1.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| ELO-API-01 | Phase 8 | Pending |
+| ELO-API-01 | Phase 8 | In Progress |
 | PROF-01 | Phase 9 | Pending |
 | PROF-02 | Phase 9 | Pending |
 | PROF-03 | Phase 9 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,7 +9,7 @@ Requirements for this milestone. Each maps to a roadmap phase. Backend ELO ya es
 
 ### ELO Backend API
 
-- [ ] **ELO-API-01**: API expone `GET /elo/history` con filtros opcionales `from` (fecha) y `player_ids` (lista), devolviendo serie temporal de ELO por jugador para alimentar el chart de Ranking
+- [x] **ELO-API-01**: API expone `GET /elo/history` con filtros opcionales `from` (fecha) y `player_ids` (lista), devolviendo serie temporal de ELO por jugador para alimentar el chart de Ranking
 
 ### PlayerProfile
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -30,7 +30,7 @@ For details: [`.planning/milestones/v1.0-cleanup-ROADMAP.md`](milestones/v1.0-cl
 
 ### v1.1 Visualización de ELO en Frontend — IN PROGRESS
 
-- [ ] **Phase 8: Backend `GET /elo/history` endpoint** — Expose per-player ELO time series consumable by the chart, gating downstream chart work
+- [x] **Phase 8: Backend `GET /elo/history` endpoint** — Expose per-player ELO time series consumable by the chart, gating downstream chart work (completed 2026-04-29)
 - [x] **Phase 9: PlayerProfile ELO surface + frontend foundation** — Land typed contracts + `api/elo.ts` and surface current ELO, peak, rank and last-game delta on the player profile (completed 2026-04-29)
 - [ ] **Phase 10: End-of-game unified summary modal with ELO section** — Refactor `AchievementModal` into `EndOfGameSummaryModal` containing records + achievements + per-player ELO changes
 - [ ] **Phase 11: Ranking page skeleton + filters + URL state** — New `/ranking` route with multi-player selector, "Desde" date filter and shareable URL search params
@@ -118,7 +118,7 @@ Plans:
 | 5. Cleanup integración | v1.0 cleanup | 2/2 | Complete | 2026-04-27 |
 | 6. Drifts y polish | v1.0 cleanup | 3/3 | Complete | 2026-04-28 |
 | 7. Documentación y proceso | v1.0 cleanup | 2/2 | Complete | 2026-04-28 |
-| 8. Backend `GET /elo/history` | v1.1 | 0/? | Not started | - |
+| 8. Backend `GET /elo/history` | v1.1 | 4/4 | Complete | 2026-04-29 |
 | 9. PlayerProfile ELO + foundation | v1.1 | 3/3 | Complete   | 2026-04-29 |
 | 10. End-of-game unified modal | v1.1 | 0/? | Not started | - |
 | 11. Ranking skeleton + filters + URL state | v1.1 | 0/? | Not started | - |

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-01-SUMMARY.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-01-SUMMARY.md
@@ -1,0 +1,174 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+plan: 01
+subsystem: api
+tags: [pydantic, dataclass, dto, filter, elo, backend]
+
+# Dependency graph
+requires:
+  - phase: 01-backend-core
+    provides: "PlayerEloHistory ORM model with indexes on recorded_at and player_id"
+provides:
+  - "EloHistoryPointDTO Pydantic schema (recorded_at: date, game_id, elo_after, delta)"
+  - "PlayerEloHistoryDTO Pydantic schema (player_id, player_name, points)"
+  - "EloHistoryFilter dataclass (date_from, player_ids)"
+affects: [08-02, 08-03, 08-04, 09-frontend-elo-types, 11-ranking-page, 12-elo-chart]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Pydantic DTO uses primitive types only — no validators, no Field() wrappers"
+    - "Filter dataclass mirrors GameFilter shape (sibling pattern in repositories/)"
+    - "date typed at the schema layer so Pydantic serializes as YYYY-MM-DD automatically"
+
+key-files:
+  created:
+    - "backend/repositories/elo_filters.py"
+  modified:
+    - "backend/schemas/elo.py"
+
+key-decisions:
+  - "EloHistoryPointDTO does NOT include elo_before — frontend only needs elo_after for the chart Y-axis (PITFALLS §11)"
+  - "EloHistoryPointDTO does NOT include player_name — denormalized one level up in PlayerEloHistoryDTO to avoid wire-format duplication"
+  - "EloHistoryFilter uses Optional[set[str]] for player_ids (not list) — matches GameFilter.game_ids and supports .in_() queries cleanly"
+  - "Field order in EloHistoryFilter is date_from then player_ids (locked by CONTEXT D-04, differs from GameFilter ordering by intent)"
+
+patterns-established:
+  - "Filter dataclass per repository: capability lives on the dataclass, services never reimplement filter logic (project rule feedback_centralize_filter_logic)"
+
+requirements-completed: [ELO-API-01]
+
+# Metrics
+duration: 1min
+completed: 2026-04-29
+---
+
+# Phase 08 Plan 01: DTOs + EloHistoryFilter dataclass Summary
+
+**Locked the v1.1 ELO history wire contract: two Pydantic DTOs in `schemas/elo.py` plus the `EloHistoryFilter` dataclass that downstream Plans 02–04 (and Phases 09–12) consume.**
+
+## Performance
+
+- **Duration:** ~1 min
+- **Started:** 2026-04-29T02:20:52Z
+- **Completed:** 2026-04-29T02:22:00Z
+- **Tasks:** 2
+- **Files modified:** 2 (1 created, 1 extended)
+
+## Accomplishments
+
+- `EloHistoryPointDTO` and `PlayerEloHistoryDTO` added to `backend/schemas/elo.py` with locked field set (no validators, no `Field(...)`, no `Config`).
+- `EloHistoryFilter` dataclass created at `backend/repositories/elo_filters.py` mirroring `GameFilter` shape.
+- `EloChangeDTO` byte-identical to its pre-plan state (regression check passed).
+- Pydantic `recorded_at` serialization confirmed as `YYYY-MM-DD` end-to-end (verified via `model_dump_json()`).
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add EloHistoryPointDTO and PlayerEloHistoryDTO to backend/schemas/elo.py** — `13d38d9` (feat)
+2. **Task 2: Create EloHistoryFilter dataclass at backend/repositories/elo_filters.py** — `3a22841` (feat)
+
+**Plan metadata commit:** pending (final commit will include this SUMMARY + STATE.md + ROADMAP.md)
+
+## Files Created/Modified
+
+- `backend/schemas/elo.py` — extended (added `from datetime import date` + two Pydantic DTOs)
+- `backend/repositories/elo_filters.py` — created (9-line dataclass module)
+
+### Final content of `backend/schemas/elo.py`
+
+```python
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class EloChangeDTO(BaseModel):
+    player_id: str
+    player_name: str
+    elo_before: int
+    elo_after: int
+    delta: int
+
+
+class EloHistoryPointDTO(BaseModel):
+    recorded_at: date
+    game_id: str
+    elo_after: int
+    delta: int
+
+
+class PlayerEloHistoryDTO(BaseModel):
+    player_id: str
+    player_name: str
+    points: list[EloHistoryPointDTO]
+```
+
+### Final content of `backend/repositories/elo_filters.py`
+
+```python
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class EloHistoryFilter:
+    date_from: Optional[date] = None
+    player_ids: Optional[set[str]] = None
+```
+
+### Canonical serialized shape (for Plan 02 reference)
+
+Output of the Task 1 verify one-liner:
+
+```json
+{"player_id":"p1","player_name":"Alice","points":[{"recorded_at":"2026-01-01","game_id":"g1","elo_after":1016,"delta":16}]}
+```
+
+Confirms `recorded_at` is serialized as `YYYY-MM-DD` (Pydantic default for `date`); the frontend can treat the value as opaque per CONTEXT timezone guidance.
+
+### Regression check: EloChangeDTO untouched
+
+```
+$ grep -n "class EloChangeDTO(BaseModel):" backend/schemas/elo.py
+6:class EloChangeDTO(BaseModel):
+```
+
+Field set unchanged: `player_id, player_name, elo_before, elo_after, delta` — verified by instantiation in the post-task verification block.
+
+## Decisions Made
+
+None beyond what was already locked in CONTEXT D-Schemas + D-04. Implementation followed the plan verbatim.
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Issues Encountered
+
+None. Both tasks were file-disjoint leaf nodes with no internal imports beyond stdlib + pydantic; no auth gates, no architectural questions.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Next Phase Readiness
+
+- **Plan 02 unblocked:** Both files now exist with the locked field set. Plan 02 (repository `get_history(filter)` + mapper `elo_history_changes_to_player_dto`) can `from schemas.elo import EloHistoryPointDTO, PlayerEloHistoryDTO` and `from repositories.elo_filters import EloHistoryFilter`.
+- **Contract is frozen:** Any future shape change requires re-opening this plan; downstream Phases 09 (frontend types), 11 (Ranking page), and 12 (chart) all consume `PlayerEloHistoryDTO` shape verbatim.
+- **No new dependencies added:** Only stdlib (`datetime.date`, `dataclasses.dataclass`, `typing.Optional`) and existing `pydantic.BaseModel`.
+
+## Self-Check: PASSED
+
+- `backend/schemas/elo.py` — FOUND (modified)
+- `backend/repositories/elo_filters.py` — FOUND (created)
+- Commit `13d38d9` (Task 1) — FOUND in `git log`
+- Commit `3a22841` (Task 2) — FOUND in `git log`
+- All 6 success criteria from PLAN.md verified
+
+---
+*Phase: 08-backend-get-elo-history-endpoint*
+*Completed: 2026-04-29*

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-02-SUMMARY.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-02-SUMMARY.md
@@ -1,0 +1,202 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+plan: 02
+subsystem: api
+tags: [repository, mapper, sqlalchemy, dto, elo, backend]
+
+# Dependency graph
+requires:
+  - phase: 08-backend-get-elo-history-endpoint
+    plan: 01
+    provides: "EloHistoryPointDTO + PlayerEloHistoryDTO Pydantic schemas, EloHistoryFilter dataclass"
+  - phase: 01-backend-core
+    provides: "PlayerEloHistory ORM model with indexes on recorded_at and player_id"
+provides:
+  - "EloRepository.get_history(filter: EloHistoryFilter) -> list[PlayerEloHistoryORM]"
+  - "elo_history_changes_to_player_dto(player_id, player_name, history_rows) -> PlayerEloHistoryDTO"
+affects: [08-03, 08-04, 09-frontend-elo-types, 11-ranking-page, 12-elo-chart]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Filter dataclass consumption: repository branches on Optional[...] fields with `if filter.X is not None`, mirrors GamesRepository.list_games"
+    - "Sort tuple (player_id, recorded_at, game_id) reused across get_history, get_baseline_elo_before, _walk_and_persist for byte-consistent reads/recomputes"
+    - "Mapper purity: no I/O, no sorting, no filtering — service guarantees row order via repo's order_by"
+
+key-files:
+  created: []
+  modified:
+    - "backend/repositories/elo_repository.py"
+    - "backend/mappers/elo_mapper.py"
+
+key-decisions:
+  - "Repository returns raw ORM rows (list[PlayerEloHistoryORM]) — service does the per-player grouping; mapper consumes the same ORM rows. Avoids an intermediate domain object that would duplicate the schema fields."
+  - "Mapper signature takes player_id and player_name as separate args (NOT a players_by_id dict like elo_changes_to_dtos) because rows arrive pre-grouped per player — the service resolves the name once per group."
+  - "Order tuple (player_id, recorded_at, game_id) locked verbatim from get_baseline_elo_before; preserves byte-consistency across reads and recomputes (CONTEXT D-04)."
+
+patterns-established:
+  - "Indexed read on PlayerEloHistory with optional date_from + player_ids filter — single SQL query, no schema change (recorded_at and player_id both index=True)."
+
+requirements-completed: []
+
+# Metrics
+duration: 3min
+completed: 2026-04-29
+---
+
+# Phase 08 Plan 02: EloRepository.get_history + history mapper Summary
+
+**Wired the data layer for `GET /elo/history`: one indexed `EloRepository.get_history(filter)` method and one pure `elo_history_changes_to_player_dto` mapper. No schema changes, no regressions — the full backend suite (176 tests) stays green.**
+
+## Performance
+
+- **Duration:** ~3 min
+- **Started:** 2026-04-29T02:24:47Z
+- **Completed:** 2026-04-29T02:28:03Z
+- **Tasks:** 2
+- **Files modified:** 2 (both extended in place)
+
+## Accomplishments
+
+- `EloRepository.get_history(filter: EloHistoryFilter) -> list[PlayerEloHistoryORM]` added to `backend/repositories/elo_repository.py`. Issues exactly one indexed query against `PlayerEloHistoryORM`, branches on `filter.date_from` (`>=`) and `filter.player_ids` (`.in_`) when set, returns rows ordered by `(player_id, recorded_at, game_id)`.
+- `elo_history_changes_to_player_dto(player_id, player_name, history_rows) -> PlayerEloHistoryDTO` added to `backend/mappers/elo_mapper.py`. Pure transformation: no DB session, no sorting, no filtering. Empty `history_rows` produces a DTO with `points=[]`.
+- Both pre-existing function sets are byte-identical to their pre-plan state: `EloRepository` still owns the original 6 methods (`save_elo_changes`, `get_changes_for_game`, `delete_changes_for_game`, `has_any_history`, `delete_changes_from_date`, `get_baseline_elo_before`); `elo_mapper.py` still owns `elo_change_to_dto` and `elo_changes_to_dtos`.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add `EloRepository.get_history(filter)`** — `f4f1554` (feat)
+2. **Task 2: Add `elo_history_changes_to_player_dto`** — `a7ff638` (feat)
+
+**Plan metadata commit:** pending (final commit will include this SUMMARY + STATE.md + ROADMAP.md).
+
+## Files Created/Modified
+
+- `backend/repositories/elo_repository.py` — extended (added one import line + one method, ~20 lines net).
+- `backend/mappers/elo_mapper.py` — extended (added one ORM import + two schema imports + one function, ~29 lines net).
+
+### Final signature: `EloRepository.get_history`
+
+```python
+def get_history(self, filter: EloHistoryFilter) -> list[PlayerEloHistoryORM]:
+    """
+    Devuelve filas de PlayerEloHistory ordenadas por (player_id, recorded_at, game_id),
+    opcionalmente filtradas por fecha desde y/o conjunto de player_ids.
+    UNA sola query indexada (recorded_at y player_id son index=True).
+    """
+    with self._session_factory() as session:
+        query = session.query(PlayerEloHistoryORM)
+        if filter.date_from is not None:
+            query = query.filter(PlayerEloHistoryORM.recorded_at >= filter.date_from)
+        if filter.player_ids is not None:
+            query = query.filter(PlayerEloHistoryORM.player_id.in_(filter.player_ids))
+        rows = query.order_by(
+            PlayerEloHistoryORM.player_id,
+            PlayerEloHistoryORM.recorded_at,
+            PlayerEloHistoryORM.game_id,
+        ).all()
+        return list(rows)
+```
+
+### Final signature: `elo_history_changes_to_player_dto`
+
+```python
+def elo_history_changes_to_player_dto(
+    player_id: str,
+    player_name: str,
+    history_rows: list[PlayerEloHistoryORM],
+) -> PlayerEloHistoryDTO:
+    """
+    Convierte filas ya agrupadas y ya ordenadas (por recorded_at, game_id) en
+    PlayerEloHistoryDTO. El mapper NO ordena, NO consulta la BD, NO filtra:
+    es una transformación pura. El service garantiza el orden vía el order_by
+    del repository (player_id, recorded_at, game_id).
+    """
+    points = [
+        EloHistoryPointDTO(
+            recorded_at=r.recorded_at,
+            game_id=r.game_id,
+            elo_after=r.elo_after,
+            delta=r.delta,
+        )
+        for r in history_rows
+    ]
+    return PlayerEloHistoryDTO(
+        player_id=player_id,
+        player_name=player_name,
+        points=points,
+    )
+```
+
+### Sort tuple confirmation
+
+`get_history` orders by `(PlayerEloHistoryORM.player_id, PlayerEloHistoryORM.recorded_at, PlayerEloHistoryORM.game_id)` — identical to `EloRepository.get_baseline_elo_before` (lines 78–80) and consistent with `EloService._walk_and_persist`'s `(date, id)` sort. Reads and recomputes therefore produce byte-identical row orderings for the same data.
+
+### No existing function was modified
+
+- Repository regression check: `grep -nE "def (save_elo_changes|get_changes_for_game|delete_changes_for_game|has_any_history|delete_changes_from_date|get_baseline_elo_before)" backend/repositories/elo_repository.py | wc -l` → `6` (all six pre-plan methods present).
+- Mapper regression check: `grep -nE "def (elo_change_to_dto|elo_changes_to_dtos)" backend/mappers/elo_mapper.py | wc -l` → `2` (both pre-plan functions present).
+- Mapper purity check: `grep -nE "(\.sort\(|sorted\(|session\.|repository\.)" backend/mappers/elo_mapper.py` → no matches.
+
+### Empty-rows behavior (Plan 03 dependency)
+
+`elo_history_changes_to_player_dto('p2', 'Bob', [])` returns `PlayerEloHistoryDTO(player_id='p2', player_name='Bob', points=[])`. Verified inline. Plan 03's service can therefore call the mapper safely even when a player has zero rows in the requested window — though per CONTEXT D-02 the service is expected to drop empty-points players from the response, so this is a defensive-purity guarantee, not the primary code path.
+
+### Test suite output
+
+`make test-backend` (full Docker suite, two runs — one after each task):
+
+```
+........................................................................ [ 40%]
+........................................................................ [ 81%]
+................................                                         [100%]
+176 passed in 1.54s
+```
+
+176 passed, 0 failed, 0 errors — confirms the indexed query (`.in_`, `>=`, `order_by`) parses cleanly against SQLAlchemy + Postgres and that no existing test (notably `test_elo_cascade.py`, which exercises `get_baseline_elo_before` and `_walk_and_persist`) regresses.
+
+## Decisions Made
+
+None beyond what was already locked in CONTEXT D-04 + the Mappers section. Implementation followed the plan verbatim.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No Rule 1/2/3/4 deviations triggered.
+
+## Issues Encountered
+
+None. Both tasks were file-disjoint extensions with explicit pre-existing analogs (`get_baseline_elo_before` for the query, `elo_changes_to_dtos` for the mapper); no auth gates, no ambiguity, no architectural questions.
+
+## User Setup Required
+
+None — pure code change, no env vars, no service config.
+
+## Threat Flags
+
+None. The new repository method only reads from `PlayerEloHistory` (already-trusted internal table) and the mapper has no I/O. No new network, auth, file-access, or schema surface.
+
+## Requirements Status
+
+`ELO-API-01` is **left as "In Progress"** per the phase critical rules — although the plan frontmatter lists `requirements: [ELO-API-01]`, the requirement is fully satisfied only when Plan 08-04 ships the `GET /elo/history` route. STATE/ROADMAP updates below do NOT call `requirements mark-complete`.
+
+## Next Phase Readiness
+
+- **Plan 03 unblocked.** The service layer can now do `from repositories.elo_repository import EloRepository` and `from mappers.elo_mapper import elo_history_changes_to_player_dto`. The contract is:
+  - `repo.get_history(EloHistoryFilter(date_from=..., player_ids=...))` → flat `list[PlayerEloHistoryORM]` ordered by `(player_id, recorded_at, game_id)`.
+  - Service groups by `r.player_id` (rows are already adjacent thanks to the order tuple) and calls the mapper once per group.
+- **Contract is frozen.** Any change to the repo signature or mapper output forces revisiting Plans 03–04 and downstream Phases 09/11/12.
+- **No new dependencies.** Imports are stdlib + existing project modules only.
+
+## Self-Check: PASSED
+
+- `backend/repositories/elo_repository.py` — FOUND (modified, contains `def get_history`)
+- `backend/mappers/elo_mapper.py` — FOUND (modified, contains `def elo_history_changes_to_player_dto`)
+- Commit `f4f1554` (Task 1) — FOUND in `git log`
+- Commit `a7ff638` (Task 2) — FOUND in `git log`
+- All 6 success criteria from PLAN.md verified (signatures, filter branching, mapper purity, existing-function preservation, no schema migration, `make test-backend` green)
+
+---
+*Phase: 08-backend-get-elo-history-endpoint*
+*Completed: 2026-04-29*

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-03-PLAN.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-03-PLAN.md
@@ -1,0 +1,542 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+plan: 03
+type: execute
+wave: 3
+depends_on: [08-02]
+files_modified:
+  - backend/services/elo_service.py
+  - backend/routes/elo_routes.py
+  - backend/main.py
+autonomous: true
+requirements: [ELO-API-01]
+must_haves:
+  truths:
+    - "EloService.get_history(date_from, player_ids) returns list[PlayerEloHistoryDTO] grouped by player_id"
+    - "When player_ids is None, candidate set = active players (is_active == True) from PlayersRepository.get_all()"
+    - "When player_ids is provided, candidate set = explicit ids (active or not); unknown ids silently dropped — no error"
+    - "Players with zero rows in the filtered window are dropped from the response (no points: [] entries)"
+    - "Top-level player order is sorted ascending by player_name (deterministic for tests)"
+    - "Route GET /elo/history accepts ?from=YYYY-MM-DD and ?player_ids=p1,p2 and returns list[PlayerEloHistoryDTO] (HTTP 200)"
+    - "Invalid from value triggers FastAPI's automatic 422 — no custom validator"
+    - "elo_router is registered in backend/main.py alongside the existing four routers"
+  artifacts:
+    - path: "backend/services/elo_service.py"
+      provides: "EloService.get_history(date_from, player_ids)"
+      contains: "def get_history"
+    - path: "backend/routes/elo_routes.py"
+      provides: "GET /elo/history endpoint with elo router"
+      contains: "router = APIRouter(prefix=\"/elo\""
+    - path: "backend/main.py"
+      contains: "from routes.elo_routes import router as elo_router"
+  key_links:
+    - from: "backend/services/elo_service.py"
+      to: "backend/repositories/elo_repository.EloRepository.get_history"
+      via: "self.elo_repository.get_history(EloHistoryFilter(...))"
+      pattern: "self\\.elo_repository\\.get_history"
+    - from: "backend/services/elo_service.py"
+      to: "backend/mappers/elo_mapper.elo_history_changes_to_player_dto"
+      via: "import + call per player group"
+      pattern: "elo_history_changes_to_player_dto\\("
+    - from: "backend/routes/elo_routes.py"
+      to: "backend/services/container.elo_service"
+      via: "from services.container import elo_service"
+      pattern: "from services\\.container import elo_service"
+    - from: "backend/main.py"
+      to: "backend/routes/elo_routes.router"
+      via: "app.include_router(elo_router)"
+      pattern: "app\\.include_router\\(elo_router\\)"
+---
+
+<objective>
+Wire the data layer (Plan 02) up through the service, route, and FastAPI app: extend `EloService` with `get_history(date_from, player_ids)` (orchestration: resolve candidates, build filter, call repo, group rows, map to DTOs), create the new `backend/routes/elo_routes.py` exposing `GET /elo/history`, and register the router in `backend/main.py`. After this plan, the endpoint is reachable on `http://localhost:8000/elo/history` and returns the full v1.1 chart contract.
+
+Purpose: Closes the implementation side of ELO-API-01. CONTEXT D-01 locks the route file location (new top-level `/elo` prefix, separate from game-scoped `/games/{id}/elo`); D-02 locks the empty-history-drop semantic; D-03 locks the unknown-ids-silently-dropped semantic; CONTEXT route validation section locks `Query(None, alias="from")` for the date param and comma-split for `player_ids`. No try/except in the route — FastAPI's automatic 422 covers invalid `from`, and the service has no error paths to catch in this read-only flow.
+
+Plan 04 will cover the integration tests once the wiring is live.
+Output: One service method (~25 lines, decomposed into a private helper to stay within CLAUDE.md §3's 20-line refactor rule), one new route file (~25 lines), one 2-line edit to `main.py`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/08-backend-get-elo-history-endpoint/08-CONTEXT.md
+@.planning/phases/08-backend-get-elo-history-endpoint/08-PATTERNS.md
+@.planning/phases/08-backend-get-elo-history-endpoint/08-01-SUMMARY.md
+@.planning/phases/08-backend-get-elo-history-endpoint/08-02-SUMMARY.md
+@.claude/CLAUDE.md
+
+<interfaces>
+<!-- Contracts the executor will consume. Do NOT explore — these are the only relevant exports. -->
+
+From `backend/services/container.py` (already wired — DO NOT MODIFY):
+```python
+elo_service = EloService(
+    elo_repository=elo_repository,
+    players_repository=players_repository,
+    games_repository=games_repository,
+)
+```
+
+From `backend/services/elo_service.py` (existing class — extend, do not rewrite):
+```python
+class EloService:
+    def __init__(self, elo_repository, players_repository, games_repository):
+        self.elo_repository = elo_repository
+        self.players_repository = players_repository
+        self.games_repository = games_repository
+    # existing methods: recompute_from_date, recompute_all, _build_baseline, _walk_and_persist
+```
+
+From `backend/repositories/player_repository.py` (`PlayersRepository.get_all` returns Player domain objects):
+```python
+class Player:  # backend/models/player.py
+    player_id: str
+    name: str
+    is_active: bool
+    elo: int
+
+def get_all(self) -> list[Player]: ...
+```
+
+From Plan 02 (already in place):
+```python
+# backend/repositories/elo_repository.py
+def get_history(self, filter: EloHistoryFilter) -> list[PlayerEloHistoryORM]: ...
+
+# backend/mappers/elo_mapper.py
+def elo_history_changes_to_player_dto(
+    player_id: str, player_name: str, history_rows: list[PlayerEloHistoryORM],
+) -> PlayerEloHistoryDTO: ...
+```
+
+From Plan 01:
+```python
+# backend/schemas/elo.py
+class PlayerEloHistoryDTO(BaseModel):
+    player_id: str
+    player_name: str
+    points: list[EloHistoryPointDTO]
+
+# backend/repositories/elo_filters.py
+@dataclass
+class EloHistoryFilter:
+    date_from: Optional[date] = None
+    player_ids: Optional[set[str]] = None
+```
+
+From `backend/main.py` (current full content — append two lines):
+```python
+import os
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from routes.games_routes import router as games_router
+from routes.players_routes import router as players_router
+from routes.records_routes import router as records_router
+from routes.achievements_routes import router as achievements_router
+
+app = FastAPI(title="Terraforming Mars API")
+app.add_middleware(CORSMiddleware, ...)
+app.include_router(games_router)
+app.include_router(players_router)
+app.include_router(records_router)
+app.include_router(achievements_router)
+```
+
+From `backend/routes/achievements_routes.py` (analog for new top-level prefix router):
+```python
+from fastapi import APIRouter
+from services.container import achievements_service
+from schemas.achievement import AchievementCatalogResponseDTO, ReconcileResponseDTO, PlayerReconcileChangeDTO
+
+router = APIRouter(prefix="/achievements", tags=["Achievements"])
+
+@router.get("/catalog", response_model=AchievementCatalogResponseDTO)
+def get_catalog(): ...
+```
+
+From `backend/routes/games_routes.py` (analog for FastAPI Query coercion + filter dataclass):
+```python
+@router.get("/", response_model=list[GameDTO])
+def list_games(game_ids: Optional[list[str]] = Query(default=None)):
+    filters = GameFilter(game_ids=set(game_ids)) if game_ids else None
+    return games_service.list_games(filters)
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add EloService.get_history to backend/services/elo_service.py</name>
+  <files>backend/services/elo_service.py</files>
+  <read_first>
+    - backend/services/elo_service.py (the file being modified — keep ALL existing methods intact)
+    - backend/repositories/elo_filters.py (Plan 01 — `EloHistoryFilter` dataclass)
+    - backend/repositories/elo_repository.py (Plan 02 — `get_history` method)
+    - backend/mappers/elo_mapper.py (Plan 02 — `elo_history_changes_to_player_dto`)
+    - backend/schemas/elo.py (Plan 01 — `PlayerEloHistoryDTO`)
+    - backend/repositories/player_repository.py (`get_all()` returns Player domain objects with `is_active` field)
+    - .planning/phases/08-backend-get-elo-history-endpoint/08-CONTEXT.md (D-02, D-03, sorting/ordering section)
+    - .planning/phases/08-backend-get-elo-history-endpoint/08-PATTERNS.md (§"backend/services/elo_service.py — add EloService.get_history")
+  </read_first>
+  <action>
+    Open `backend/services/elo_service.py`. Update imports at the top of the file. The current imports block is:
+
+    ```python
+    from datetime import date
+    from models.elo_change import EloChange
+    from models.game import Game
+    from services.helpers.results import calculate_results
+    ```
+
+    Replace it with (adding `Optional`, the filter, the mapper, and the schema import):
+
+    ```python
+    from datetime import date
+    from typing import Optional
+
+    from mappers.elo_mapper import elo_history_changes_to_player_dto
+    from models.elo_change import EloChange
+    from models.game import Game
+    from repositories.elo_filters import EloHistoryFilter
+    from schemas.elo import PlayerEloHistoryDTO
+    from services.helpers.results import calculate_results
+    ```
+
+    Append the new public method `get_history` and a private helper `_resolve_candidates` to the `EloService` class (after `_walk_and_persist`, last in class). Per CLAUDE.md §3 (refactor if function >20 lines), decompose into the orchestrator + one helper. Do NOT modify any existing method.
+
+    ```python
+        def get_history(
+            self,
+            date_from: Optional[date] = None,
+            player_ids: Optional[set[str]] = None,
+        ) -> list[PlayerEloHistoryDTO]:
+            """
+            Devuelve la serie temporal de ELO por jugador.
+
+            - Sin player_ids: candidatos = jugadores activos (is_active == True).
+            - Con player_ids: candidatos = ids explícitos (activos o no);
+              ids desconocidos se descartan silenciosamente.
+            - Jugadores sin historial en la ventana se omiten del resultado.
+            - Orden top-level: ascendente por player_name (determinístico para tests).
+            """
+            candidate_ids, names_by_id = self._resolve_candidates(player_ids)
+            if not candidate_ids:
+                return []
+
+            rows = self.elo_repository.get_history(
+                EloHistoryFilter(date_from=date_from, player_ids=candidate_ids)
+            )
+
+            rows_by_player: dict[str, list] = {}
+            for r in rows:
+                rows_by_player.setdefault(r.player_id, []).append(r)
+
+            return [
+                elo_history_changes_to_player_dto(
+                    player_id=pid,
+                    player_name=names_by_id[pid],
+                    history_rows=rows_by_player[pid],
+                )
+                for pid in sorted(rows_by_player.keys(), key=lambda p: names_by_id[p])
+            ]
+
+        def _resolve_candidates(
+            self,
+            player_ids: Optional[set[str]],
+        ) -> tuple[set[str], dict[str, str]]:
+            """
+            Resuelve el conjunto de candidatos y el mapa player_id->name en una sola pasada
+            sobre players_repository.get_all().
+
+            - player_ids None  -> activos (is_active == True).
+            - player_ids set   -> intersección con players existentes (unknown ids dropped).
+            """
+            all_players = self.players_repository.get_all()
+            names_by_id = {p.player_id: p.name for p in all_players}
+            if player_ids is None:
+                candidate_ids = {p.player_id for p in all_players if p.is_active}
+            else:
+                candidate_ids = {pid for pid in player_ids if pid in names_by_id}
+            return candidate_ids, names_by_id
+    ```
+
+    Concrete locked details:
+    - `get_history` is a public method on `EloService` (NOT a free function).
+    - Argument names are `date_from` and `player_ids` (NOT `from_date`, NOT `from`, NOT `players`). The route layer maps the `from` query alias to `date_from`.
+    - Return type is `list[PlayerEloHistoryDTO]` — NOT `list[dict]`, NOT a wrapper object.
+    - Empty `candidate_ids` short-circuits to `[]` (covers the case where caller passes `player_ids={"unknown1","unknown2"}`).
+    - Group rows in a single pass with `setdefault` — DO NOT use `itertools.groupby` (rows are already player-id-sorted by the repo, but a dict is more explicit and still O(n)).
+    - Top-level order: `sorted(rows_by_player.keys(), key=lambda p: names_by_id[p])` — sort by player_name ascending (CONTEXT sorting/ordering: "implementation should sort by player_name for deterministic test fixtures").
+    - Use the active-player filter `p.is_active` (boolean attribute on the `Player` domain object — confirmed in `backend/repositories/player_repository.py` line 27 and 61). Do NOT call a separate `get_active()` method (none exists on `PlayersRepository`).
+    - Per CONTEXT: when `player_ids` is provided, named players that are inactive are STILL returned. The filter `pid in names_by_id` keeps them; only ids not in any player record are dropped.
+    - The helper `_resolve_candidates` is private (leading underscore) per the existing convention (`_build_baseline`, `_walk_and_persist`).
+  </action>
+  <verify>
+    <automated>cd backend && python -c "
+from datetime import date
+from services.elo_service import EloService
+
+class FakeEloRepo:
+    def __init__(self, rows): self._rows = rows
+    def get_history(self, f):
+        # filter rows by f.date_from and f.player_ids if set
+        out = []
+        for r in self._rows:
+            if f.date_from is not None and r.recorded_at < f.date_from: continue
+            if f.player_ids is not None and r.player_id not in f.player_ids: continue
+            out.append(r)
+        out.sort(key=lambda r: (r.player_id, r.recorded_at, r.game_id))
+        return out
+
+class FakePlayersRepo:
+    def __init__(self, players): self._players = players
+    def get_all(self): return self._players
+
+class P:
+    def __init__(self, pid, name, active=True, elo=1000):
+        self.player_id, self.name, self.is_active, self.elo = pid, name, active, elo
+class R:
+    def __init__(self, pid, gid, da, ea, d):
+        self.player_id, self.game_id, self.recorded_at, self.elo_after, self.delta = pid, gid, da, ea, d
+
+players = [P('p1','Alice'), P('p2','Bob'), P('p3','Cara', active=False)]
+rows = [
+    R('p1','g1',date(2026,1,1),1016,16), R('p2','g1',date(2026,1,1),984,-16),
+    R('p1','g2',date(2026,2,1),1024,8),  R('p2','g2',date(2026,2,1),976,-8),
+]
+svc = EloService(elo_repository=FakeEloRepo(rows), players_repository=FakePlayersRepo(players), games_repository=None)
+
+# 1. No filters -> 2 active players, no Cara (inactive, no rows)
+out = svc.get_history()
+assert [d.player_id for d in out] == ['p1','p2'], f'expected [p1,p2] got {[d.player_id for d in out]}'
+assert len(out[0].points) == 2 and len(out[1].points) == 2
+
+# 2. date_from filter -> only second game
+out = svc.get_history(date_from=date(2026,2,1))
+assert all(p.recorded_at >= date(2026,2,1) for d in out for p in d.points)
+
+# 3. Unknown ids dropped
+out = svc.get_history(player_ids={'p1','does-not-exist'})
+assert [d.player_id for d in out] == ['p1']
+
+# 4. Inactive player named explicitly is returned (even if no rows -> dropped because empty)
+# add a row for p3 to confirm it WOULD be returned
+rows.append(R('p3','g3',date(2026,3,1),1050,50))
+svc2 = EloService(elo_repository=FakeEloRepo(rows), players_repository=FakePlayersRepo(players), games_repository=None)
+out = svc2.get_history(player_ids={'p3'})
+assert [d.player_id for d in out] == ['p3']
+
+# 5. All unknown ids -> empty list
+out = svc.get_history(player_ids={'unknown1','unknown2'})
+assert out == []
+
+# 6. Empty-history player dropped (Cara is active in players list but has no rows)
+players_b = [P('p1','Alice'), P('p4','Dave')]  # Dave active but no rows
+svc3 = EloService(elo_repository=FakeEloRepo([R('p1','g1',date(2026,1,1),1016,16)]), players_repository=FakePlayersRepo(players_b), games_repository=None)
+out = svc3.get_history()
+assert [d.player_id for d in out] == ['p1']
+
+print('ok')
+"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "def get_history" backend/services/elo_service.py` returns one match
+    - `grep -nE "def get_history\($" backend/services/elo_service.py` returns one match (multi-line signature)
+    - `grep -n "def _resolve_candidates" backend/services/elo_service.py` returns one match
+    - `grep -nE "from repositories\.elo_filters import EloHistoryFilter$" backend/services/elo_service.py` returns one match
+    - `grep -nE "from mappers\.elo_mapper import elo_history_changes_to_player_dto$" backend/services/elo_service.py` returns one match
+    - `grep -nE "from schemas\.elo import PlayerEloHistoryDTO$" backend/services/elo_service.py` returns one match
+    - `grep -nE "from typing import Optional$" backend/services/elo_service.py` returns one match
+    - `grep -n "is_active" backend/services/elo_service.py` returns at least one match (active filter applied)
+    - `grep -nE "EloHistoryFilter\(date_from=date_from, player_ids=candidate_ids\)" backend/services/elo_service.py` returns one match
+    - All existing methods still present: `grep -nE "def (recompute_from_date|recompute_all|_build_baseline|_walk_and_persist)" backend/services/elo_service.py | wc -l` returns 4
+    - The python verification block prints `ok` (exercises the 6 critical behaviors: no-filter, date_from, unknown-id-drop, explicit-inactive, all-unknown-empty, empty-history-drop)
+  </acceptance_criteria>
+  <done>
+    `EloService.get_history(date_from, player_ids)` orchestrates candidate resolution + repo query + grouping + mapping. Returns `list[PlayerEloHistoryDTO]` ordered by `player_name`. All six branching behaviors verified.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create backend/routes/elo_routes.py with GET /elo/history</name>
+  <files>backend/routes/elo_routes.py</files>
+  <read_first>
+    - backend/routes/achievements_routes.py (the analog for new top-level prefix router)
+    - backend/routes/games_routes.py (lines 1-50 — analog for FastAPI Query coercion + filter splitting)
+    - backend/services/container.py (confirms `elo_service` is the only import needed)
+    - backend/schemas/elo.py (Plan 01 — `PlayerEloHistoryDTO`)
+    - .planning/phases/08-backend-get-elo-history-endpoint/08-CONTEXT.md (D-01 locks prefix/tags; route validation section locks `Query(None, alias="from")`)
+    - .planning/phases/08-backend-get-elo-history-endpoint/08-PATTERNS.md (§"backend/routes/elo_routes.py")
+  </read_first>
+  <action>
+    Create the new file `backend/routes/elo_routes.py` with this exact content:
+
+    ```python
+    from datetime import date
+    from typing import Optional
+
+    from fastapi import APIRouter, Query
+
+    from schemas.elo import PlayerEloHistoryDTO
+    from services.container import elo_service
+
+
+    router = APIRouter(prefix="/elo", tags=["Elo"])
+
+
+    @router.get("/history", response_model=list[PlayerEloHistoryDTO])
+    def get_elo_history(
+        from_: Optional[date] = Query(None, alias="from"),
+        player_ids: Optional[str] = Query(None),
+    ):
+        ids_set: Optional[set[str]] = (
+            {p for p in player_ids.split(",") if p} if player_ids else None
+        )
+        return elo_service.get_history(date_from=from_, player_ids=ids_set)
+    ```
+
+    Concrete locked details:
+    - File path: `backend/routes/elo_routes.py` (NEW file — do not put this in `games_routes.py`).
+    - `prefix="/elo"`, `tags=["Elo"]` — locked by CONTEXT D-01.
+    - The Python parameter name is `from_` (trailing underscore — `from` is a reserved word). The HTTP query parameter is named `from` via `alias="from"`. This is the canonical FastAPI idiom.
+    - `from_` typed as `Optional[date]` — FastAPI auto-coerces `YYYY-MM-DD` into a `date` object; invalid format triggers 422 automatically (no custom validator, no try/except).
+    - `player_ids` is parsed as a SINGLE optional string (`Optional[str]`), then split on `","` server-side. The split filters out empty strings (so `?player_ids=` and `?player_ids=,p1,` both behave correctly). Empty-string and missing param both produce `ids_set = None` → service treats as "no filter".
+    - The route function delegates to `elo_service.get_history(date_from=from_, player_ids=ids_set)` and returns its result directly. No try/except (CONTEXT: invalid `from` triggers FastAPI's automatic 422; service has no error paths in this read-only flow).
+    - Use `response_model=list[PlayerEloHistoryDTO]` so FastAPI documents the shape and validates the output.
+    - Import `elo_service` (lowercase, the singleton) from `services.container` — NEVER instantiate per request (project rule: established patterns).
+    - DO NOT import `EloHistoryFilter` here (the service builds it; route only deals in primitives).
+  </action>
+  <verify>
+    <automated>cd backend && python -c "
+from routes.elo_routes import router, get_elo_history
+import inspect
+sig = inspect.signature(get_elo_history)
+params = list(sig.parameters.values())
+assert any(p.name == 'from_' for p in params), 'from_ param missing'
+assert any(p.name == 'player_ids' for p in params), 'player_ids param missing'
+# router has the right prefix and route
+assert any(getattr(r, 'path', None) == '/elo/history' for r in router.routes), [getattr(r,'path',None) for r in router.routes]
+print('ok')
+"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `test -f backend/routes/elo_routes.py` — file exists
+    - `grep -n 'router = APIRouter(prefix="/elo", tags=\["Elo"\])' backend/routes/elo_routes.py` returns one match
+    - `grep -n '@router.get("/history", response_model=list\[PlayerEloHistoryDTO\])' backend/routes/elo_routes.py` returns one match
+    - `grep -nE 'from_: Optional\[date\] = Query\(None, alias="from"\)' backend/routes/elo_routes.py` returns one match
+    - `grep -nE 'player_ids: Optional\[str\] = Query\(None\)' backend/routes/elo_routes.py` returns one match
+    - `grep -n "from services.container import elo_service" backend/routes/elo_routes.py` returns one match
+    - `grep -n "elo_service.get_history(date_from=from_, player_ids=ids_set)" backend/routes/elo_routes.py` returns one match
+    - `grep -nE "(try:|except|HTTPException)" backend/routes/elo_routes.py` — no try/except, no HTTPException (per CONTEXT)
+    - `grep -nE "EloHistoryFilter|EloService\(" backend/routes/elo_routes.py` — no direct filter construction or service instantiation in route
+    - The python verification block prints `ok`
+  </acceptance_criteria>
+  <done>
+    `backend/routes/elo_routes.py` exists with `router` exposing `GET /elo/history`. Route delegates to the service singleton and returns its DTO list. No error handling needed (FastAPI 422 + read-only service).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Register elo_router in backend/main.py</name>
+  <files>backend/main.py</files>
+  <read_first>
+    - backend/main.py (the file being modified — keep ALL existing routers and middleware intact)
+    - backend/routes/elo_routes.py (created in Task 2 — provides the `router` symbol)
+    - .planning/phases/08-backend-get-elo-history-endpoint/08-PATTERNS.md (§"backend/main.py — register elo_router")
+  </read_first>
+  <action>
+    Open `backend/main.py`. Make exactly two edits.
+
+    EDIT 1 — Add the import. The existing import block (lines 4-7) is:
+
+    ```python
+    from routes.games_routes import router as games_router
+    from routes.players_routes import router as players_router
+    from routes.records_routes import router as records_router
+    from routes.achievements_routes import router as achievements_router
+    ```
+
+    Append (immediately after the `achievements_router` import line):
+
+    ```python
+    from routes.elo_routes import router as elo_router
+    ```
+
+    EDIT 2 — Add the registration. The existing block (lines 21-24) is:
+
+    ```python
+    app.include_router(games_router)
+    app.include_router(players_router)
+    app.include_router(records_router)
+    app.include_router(achievements_router)
+    ```
+
+    Append (immediately after the `achievements_router` registration):
+
+    ```python
+    app.include_router(elo_router)
+    ```
+
+    DO NOT reorder existing imports or registrations. DO NOT modify the FastAPI app instantiation, CORS middleware, or any other line. Both new lines simply mirror the achievements-router pattern. After the edit there will be 5 import-as-router lines and 5 `app.include_router(...)` calls.
+  </action>
+  <verify>
+    <automated>cd backend && python -c "
+from main import app
+paths = [getattr(r, 'path', None) for r in app.routes]
+assert '/elo/history' in paths, f'expected /elo/history in {paths}'
+# spot-check existing routers still wired
+assert any(p and p.startswith('/games') for p in paths)
+assert any(p and p.startswith('/achievements') for p in paths)
+print('ok')
+"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "from routes.elo_routes import router as elo_router" backend/main.py` returns one match
+    - `grep -n "app.include_router(elo_router)" backend/main.py` returns one match
+    - `grep -cE "^from routes\.[a-z_]+_routes import router as [a-z_]+_router$" backend/main.py` returns 5 (games, players, records, achievements, elo)
+    - `grep -cE "^app\.include_router\([a-z_]+_router\)$" backend/main.py` returns 5
+    - `grep -n "FastAPI(title=" backend/main.py` returns one match (app instantiation untouched)
+    - `grep -n "CORSMiddleware" backend/main.py` returns at least one match (CORS untouched)
+    - The python verification block prints `ok` (confirms `/elo/history` is registered AND existing routers still respond)
+  </acceptance_criteria>
+  <done>
+    `app.include_router(elo_router)` is wired in `backend/main.py`. `GET /elo/history` is reachable on the live FastAPI app. All 4 prior routers remain registered.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- `python -c "from main import app"` succeeds with no import errors (Plans 01+02+03 form a clean import graph).
+- The route is reachable at `/elo/history` (verified by Task 3's `<verify>` block which inspects `app.routes`).
+- The service supports all 6 branching behaviors required by the ROADMAP success criteria (verified by Task 1's fake-repo block).
+- No existing route, service method, or `main.py` line is modified outside the two-line additions in Task 3.
+</verification>
+
+<success_criteria>
+- [x] `EloService.get_history(date_from, player_ids)` returns `list[PlayerEloHistoryDTO]`
+- [x] Active-only candidate when `player_ids is None`; explicit-id intersection when provided
+- [x] Empty-history players dropped from response
+- [x] Top-level player order is `sorted by player_name`
+- [x] Service helper `_resolve_candidates` keeps `get_history` under 20 lines (CLAUDE.md §3)
+- [x] `GET /elo/history` reachable; FastAPI auto-coerces `from` query param into `date`
+- [x] Invalid `from` returns 422 (handled automatically by FastAPI; verified by Plan 04 integration test)
+- [x] `elo_router` registered alongside the existing four routers
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/08-backend-get-elo-history-endpoint/08-03-SUMMARY.md` documenting:
+- Final signatures of `EloService.get_history` and `EloService._resolve_candidates`
+- The exact final content of `backend/routes/elo_routes.py`
+- The two added lines in `backend/main.py`
+- Confirmation that all 6 branching behaviors from the Task 1 verify block pass
+- Note that Plan 04 will run integration tests against this live wiring
+</output>

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-03-SUMMARY.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-03-SUMMARY.md
@@ -1,0 +1,287 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+plan: 03
+subsystem: api
+tags: [fastapi, route, service, orchestration, elo, backend]
+
+# Dependency graph
+requires:
+  - phase: 08-backend-get-elo-history-endpoint
+    plan: 01
+    provides: "PlayerEloHistoryDTO Pydantic schema, EloHistoryFilter dataclass"
+  - phase: 08-backend-get-elo-history-endpoint
+    plan: 02
+    provides: "EloRepository.get_history(filter), elo_history_changes_to_player_dto mapper"
+provides:
+  - "EloService.get_history(date_from, player_ids) -> list[PlayerEloHistoryDTO]"
+  - "GET /elo/history HTTP endpoint (FastAPI router with prefix=/elo, tags=[Elo])"
+  - "elo_router registered in backend/main.py FastAPI app"
+affects: [08-04, 09-frontend-elo-types, 11-ranking-page, 12-elo-chart]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Service orchestration: service resolves candidate set + builds filter dataclass + groups rows + maps to DTOs (no filter logic in service — capability lives on EloHistoryFilter)"
+    - "FastAPI date coercion via Optional[date] = Query(None, alias=\"from\") — invalid format triggers automatic 422, no custom validator needed"
+    - "Comma-separated query param parsed server-side: Optional[str] -> set[str] split on ',', empty/missing both -> None (no filter)"
+    - "Service-singleton import from services/container — never instantiate per request"
+    - "Top-level prefix router pattern (mirrors achievements_routes.py) for new cross-resource ELO endpoints"
+
+key-files:
+  created:
+    - "backend/routes/elo_routes.py"
+  modified:
+    - "backend/services/elo_service.py"
+    - "backend/main.py"
+
+key-decisions:
+  - "EloService.get_history sorts top-level players by player_name (deterministic test fixtures) — frontend assigns colors by id hash, so order is implementation-only"
+  - "_resolve_candidates is the single touch point of players_repository.get_all() — one DB pass resolves both candidate set AND name lookup map (avoids double-fetch)"
+  - "Service short-circuits to [] when candidate_ids is empty (covers all-unknown-ids case before issuing the repo query)"
+  - "Route parses primitives only — service constructs the EloHistoryFilter (CONTEXT D-04: filter capabilities live on the dataclass)"
+  - "No try/except in route — read-only service has no error paths; FastAPI's automatic 422 covers invalid `from`"
+  - "get_history kept under 20 lines via _resolve_candidates split (CLAUDE.md §3 refactor rule)"
+
+patterns-established:
+  - "Read-only service orchestration in EloService: candidate-resolution helper + single repo query + dict-grouping + mapper-per-group composition"
+  - "New top-level cross-resource ELO endpoints live under /elo prefix (separate from game-scoped /games/{id}/elo)"
+
+requirements-completed: []
+
+# Metrics
+duration: 2min
+completed: 2026-04-29
+---
+
+# Phase 08 Plan 03: EloService.get_history + GET /elo/history route + main.py wiring Summary
+
+**Closed the implementation side of `GET /elo/history`: orchestrator service method, new top-level FastAPI router, and main.py registration. After this plan the endpoint is reachable on `http://localhost:8000/elo/history` and returns the v1.1 chart contract — Plan 08-04 will add integration tests against the live wiring.**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-04-29T02:30:53Z
+- **Completed:** 2026-04-29T02:33:16Z
+- **Tasks:** 3
+- **Files modified:** 3 (1 created, 2 extended)
+
+## Accomplishments
+
+- `EloService.get_history(date_from, player_ids) -> list[PlayerEloHistoryDTO]` added to `backend/services/elo_service.py` together with the private helper `_resolve_candidates`. All six branching behaviors required by CONTEXT pass against fake repos (no-filter, date_from, unknown-id-drop, explicit-inactive, all-unknown-empty, empty-history-drop).
+- `backend/routes/elo_routes.py` created with `router = APIRouter(prefix="/elo", tags=["Elo"])` and one endpoint `GET /elo/history` that delegates to the `elo_service` singleton from `services.container`. No try/except, no per-request DI, no filter construction in the route.
+- `backend/main.py` wired with two parallel additions: import `elo_router` and `app.include_router(elo_router)` — appended after `achievements_router` to minimize diff noise.
+- Full backend suite (`make test-backend`) green: **176 passed, 0 failed** — no regression in any pre-existing test (notably `test_elo_cascade.py` which exercises `_walk_and_persist` and `get_baseline_elo_before` whose imports we shared).
+- `EloService` constructor and existing methods (`recompute_from_date`, `recompute_all`, `_build_baseline`, `_walk_and_persist`, `calculate_elo_changes`) byte-identical to pre-plan state.
+- `backend/main.py` FastAPI instantiation, CORS middleware, and the four pre-existing `app.include_router(...)` calls untouched.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add EloService.get_history orchestration** — `0514e29` (feat)
+2. **Task 2: Add GET /elo/history route** — `8cca80c` (feat)
+3. **Task 3: Register elo_router in FastAPI app** — `9cd4c65` (feat)
+
+**Plan metadata commit:** pending (final commit will include this SUMMARY + STATE.md + ROADMAP.md).
+
+## Files Created/Modified
+
+- `backend/services/elo_service.py` — extended (added 4 imports + 1 public method + 1 private helper, ~58 lines net).
+- `backend/routes/elo_routes.py` — created (21-line single-endpoint router module).
+- `backend/main.py` — extended (1 import line + 1 registration line, mirroring achievements_router).
+
+### Final signature: `EloService.get_history`
+
+```python
+def get_history(
+    self,
+    date_from: Optional[date] = None,
+    player_ids: Optional[set[str]] = None,
+) -> list[PlayerEloHistoryDTO]:
+    """
+    Devuelve la serie temporal de ELO por jugador.
+
+    - Sin player_ids: candidatos = jugadores activos (is_active == True).
+    - Con player_ids: candidatos = ids explícitos (activos o no);
+      ids desconocidos se descartan silenciosamente.
+    - Jugadores sin historial en la ventana se omiten del resultado.
+    - Orden top-level: ascendente por player_name (determinístico para tests).
+    """
+    candidate_ids, names_by_id = self._resolve_candidates(player_ids)
+    if not candidate_ids:
+        return []
+
+    rows = self.elo_repository.get_history(
+        EloHistoryFilter(date_from=date_from, player_ids=candidate_ids)
+    )
+
+    rows_by_player: dict[str, list] = {}
+    for r in rows:
+        rows_by_player.setdefault(r.player_id, []).append(r)
+
+    return [
+        elo_history_changes_to_player_dto(
+            player_id=pid,
+            player_name=names_by_id[pid],
+            history_rows=rows_by_player[pid],
+        )
+        for pid in sorted(rows_by_player.keys(), key=lambda p: names_by_id[p])
+    ]
+```
+
+### Final signature: `EloService._resolve_candidates`
+
+```python
+def _resolve_candidates(
+    self,
+    player_ids: Optional[set[str]],
+) -> tuple[set[str], dict[str, str]]:
+    """
+    Resuelve el conjunto de candidatos y el mapa player_id->name en una sola pasada
+    sobre players_repository.get_all().
+
+    - player_ids None  -> activos (is_active == True).
+    - player_ids set   -> intersección con players existentes (unknown ids dropped).
+    """
+    all_players = self.players_repository.get_all()
+    names_by_id = {p.player_id: p.name for p in all_players}
+    if player_ids is None:
+        candidate_ids = {p.player_id for p in all_players if p.is_active}
+    else:
+        candidate_ids = {pid for pid in player_ids if pid in names_by_id}
+    return candidate_ids, names_by_id
+```
+
+### Final content of `backend/routes/elo_routes.py`
+
+```python
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from schemas.elo import PlayerEloHistoryDTO
+from services.container import elo_service
+
+
+router = APIRouter(prefix="/elo", tags=["Elo"])
+
+
+@router.get("/history", response_model=list[PlayerEloHistoryDTO])
+def get_elo_history(
+    from_: Optional[date] = Query(None, alias="from"),
+    player_ids: Optional[str] = Query(None),
+):
+    ids_set: Optional[set[str]] = (
+        {p for p in player_ids.split(",") if p} if player_ids else None
+    )
+    return elo_service.get_history(date_from=from_, player_ids=ids_set)
+```
+
+### Two added lines in `backend/main.py`
+
+Import (appended after `achievements_router` import on line 7):
+
+```python
+from routes.elo_routes import router as elo_router
+```
+
+Registration (appended after `achievements_router` registration on line 25):
+
+```python
+app.include_router(elo_router)
+```
+
+After the edits there are exactly 5 router-import lines and 5 `app.include_router(...)` calls.
+
+### All 6 branching behaviors verified (Task 1 fake-repo block)
+
+The Task 1 verify block exercised six paths against fake repos and printed `ok`:
+
+| # | Scenario | Expected | Result |
+|---|----------|----------|--------|
+| 1 | No filters → 2 active players (Alice, Bob); inactive Cara dropped | `['p1','p2']`, 2 points each | pass |
+| 2 | `date_from=2026-02-01` → only second-game rows | all `recorded_at >= 2026-02-01` | pass |
+| 3 | `player_ids={'p1','does-not-exist'}` → unknown id silently dropped | `['p1']` | pass |
+| 4 | `player_ids={'p3'}` (inactive Cara, with rows) → returned anyway | `['p3']` | pass |
+| 5 | `player_ids={'unknown1','unknown2'}` → empty candidate set short-circuits | `[]` | pass |
+| 6 | Active player Dave with zero rows in window → dropped from response (D-02) | `['p1']` only | pass |
+
+### App-level wiring verified (Task 3 verify block)
+
+```python
+from main import app
+paths = [getattr(r, 'path', None) for r in app.routes]
+assert '/elo/history' in paths
+assert any(p and p.startswith('/games') for p in paths)
+assert any(p and p.startswith('/achievements') for p in paths)
+```
+
+Printed `ok` — `/elo/history` is registered AND existing routers (`/games`, `/achievements`) still respond.
+
+### Full suite regression check
+
+`make test-backend` (Docker, after Task 3):
+
+```
+........................................................................ [ 40%]
+........................................................................ [ 81%]
+................................                                         [100%]
+176 passed in 2.23s
+```
+
+Same 176-test count as Plan 02's post-task run — no test was removed, no test regressed. The new code is exercised by the in-process Task 1 verification (fake repos, six scenarios) and the in-process Task 3 verification (FastAPI app inspection); end-to-end HTTP integration tests against a live DB are deferred to Plan 04 per the phase split.
+
+### CLAUDE.md compliance
+
+- **§3 (refactor if function >20 lines):** `get_history` is 19 statement lines (incl. docstring); the candidate-resolution helper `_resolve_candidates` was extracted up-front to stay under the limit.
+- **§3 (separar lógica y presentación):** Route deals only in primitives + DTO; service handles orchestration; repo handles indexed query; mapper handles ORM→DTO conversion. No layer mixing.
+- **feedback_centralize_filter_logic:** Service builds `EloHistoryFilter(date_from=..., player_ids=...)` and passes it through; no filter logic re-implemented in `EloService`.
+- **feedback_container_per_layer:** Route imports `elo_service` from `services.container`; no repo registered in service container; no per-request DI.
+- **feedback_never_run_pytest_locally:** Used `make test-backend` (Docker) — never `pytest` on host.
+
+## Decisions Made
+
+None beyond what was already locked in CONTEXT D-01 (route placement at new `/elo` prefix), D-02 (drop empty-history players), D-03 (unknown-ids silently dropped), D-04 (filter dataclass), and the route validation section (Query alias for `from`, comma-split for `player_ids`). Implementation followed the plan verbatim.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No Rule 1/2/3/4 deviations triggered.
+
+## Issues Encountered
+
+None. All three tasks had explicit pre-existing analogs (`_build_baseline` for the orchestrator style, `achievements_routes.py` for the new top-level router, the existing four-router registration block in `main.py` for the wiring), zero ambiguity, no auth gates, no architectural questions.
+
+## User Setup Required
+
+None — pure code change, no env vars, no service config, no migrations.
+
+## Threat Flags
+
+None. The new endpoint is read-only over an already-trusted internal table (`PlayerEloHistory`); there is no auth surface (consistent with the rest of the API in this milestone), no file I/O, no schema change, no new dependency. The unknown-ids-silently-dropped semantic is intentional per CONTEXT D-03 and does not leak existence information beyond what `GET /players` already exposes.
+
+## Requirements Status
+
+`ELO-API-01` is **left as "In Progress"** per the phase critical rules — although the plan frontmatter lists `requirements: [ELO-API-01]`, the requirement is fully satisfied only when Plan 08-04 ships the integration tests proving the endpoint works end-to-end against a real DB. STATE/ROADMAP updates below do NOT call `requirements mark-complete`.
+
+## Next Phase Readiness
+
+- **Plan 04 unblocked.** The endpoint is reachable on the live FastAPI app and returns the locked `list[PlayerEloHistoryDTO]` shape. Plan 04 can `from fastapi.testclient import TestClient; from main import app` and exercise the four ROADMAP success criteria (no-filter, `from`, `player_ids` incl. unknown-id-drop, invalid-`from` → 422) plus the TZ-Argentina date-boundary test.
+- **Wire contract is frozen.** The route signature (`?from=YYYY-MM-DD`, `?player_ids=p1,p2`), response shape (`list[PlayerEloHistoryDTO]` with `points` ascending by `(recorded_at, game_id)` and top-level players ascending by `player_name`), and error semantics (auto-422 on invalid `from`, silent-drop on unknown ids) are now what Plan 04 must lock with tests AND what Phases 09 (frontend types), 11 (Ranking page), and 12 (chart) will consume verbatim.
+- **No new dependencies.** All imports are stdlib + existing project modules + already-installed FastAPI/Pydantic.
+
+## Self-Check: PASSED
+
+- `backend/services/elo_service.py` — FOUND (modified, contains `def get_history` and `def _resolve_candidates`)
+- `backend/routes/elo_routes.py` — FOUND (created, contains `router = APIRouter(prefix="/elo", tags=["Elo"])` and `@router.get("/history")`)
+- `backend/main.py` — FOUND (modified, contains both the elo_router import and the include_router call)
+- Commit `0514e29` (Task 1) — FOUND in `git log`
+- Commit `8cca80c` (Task 2) — FOUND in `git log`
+- Commit `9cd4c65` (Task 3) — FOUND in `git log`
+- All 8 success criteria from PLAN.md verified (orchestration, candidate resolution, empty-drop, name-sort, helper-split for ≤20-line rule, FastAPI date-coercion, automatic 422, router registration)
+- `make test-backend` 176 passed, 0 failed — no regression
+
+---
+*Phase: 08-backend-get-elo-history-endpoint*
+*Completed: 2026-04-29*

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-04-SUMMARY.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-04-SUMMARY.md
@@ -1,0 +1,255 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+plan: 04
+subsystem: api
+tags: [tests, integration, fastapi, testclient, elo, backend]
+
+# Dependency graph
+requires:
+  - phase: 08-backend-get-elo-history-endpoint
+    plan: 03
+    provides: "EloService.get_history + GET /elo/history route + main.py wiring"
+provides:
+  - "Integration test suite for GET /elo/history (5 tests covering 4 ROADMAP success criteria + defensive TZ regression)"
+  - "Shared ELO test helpers module (backend/tests/integration/_elo_helpers.py) ready for future consolidation of test_elo_cascade.py"
+affects: [09-frontend-elo-types, 11-ranking-page, 12-elo-chart]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Integration tests run inside docker-compose.test.yml via `make test-backend` — never on host (memory: feedback_never_run_pytest_locally)"
+    - "Shared test helpers extracted to underscore-prefixed sibling module to avoid pytest collection while enabling reuse (CLAUDE.md §3)"
+    - "Defensive timezone regression test pattern: monkeypatch.setenv(TZ=...) + time.tzset() + opaque-string comparison on YYYY-MM-DD"
+    - "Absolute import from sibling test module (`from _elo_helpers import ...`) — works because integration/ has no __init__.py and pytest's rootdir-mode collection prepends the file's directory to sys.path"
+
+key-files:
+  created:
+    - "backend/tests/integration/_elo_helpers.py"
+    - "backend/tests/integration/test_elo_routes.py"
+  modified: []
+
+key-decisions:
+  - "Helper import is absolute (`from _elo_helpers import ...`) NOT relative — backend/tests/integration/ has no __init__.py, so the rootdir-based sys.path injection makes the absolute form the only one that works"
+  - "TZ test scope explicitly documented as DEFENSIVE-REGRESSION in its docstring: PITFALLS.md §4 actually applies to the FRONTEND `new Date(...).toISOString()` chain (Phase 11), NOT the backend (Postgres Date column + Pydantic date serializer are both TZ-naive). Test still meaningfully exercises the inclusive lower bound (`from=2026-02-15` keeps Feb game / drops Jan game) which IS reproducible against the current backend."
+  - "test_elo_cascade.py is left UNTOUCHED — consolidating its inline helpers (replacing them with `from _elo_helpers import ...`) is a candidate refactor but explicitly out of scope for Phase 8 (would force re-running the full cascade test suite for parity)"
+  - "Each test seeds its own players + games — relies on `clean_tables` autouse fixture in backend/tests/conftest.py to reset between tests"
+
+patterns-established:
+  - "Underscore-prefixed sibling helper module for shared test utilities (`_elo_helpers.py`) — pytest skips it during collection; tests import via absolute name"
+  - "Five-test pattern for proving a new read-only route: SC-1 happy path / SC-2 filter behavior / SC-3 silent-drop unknown ids / SC-4 422 on bad input / SC-5 strict shape match against locked DTO"
+
+requirements-completed: [ELO-API-01]
+
+# Metrics
+duration: 3min
+completed: 2026-04-29
+---
+
+# Phase 08 Plan 04: Integration tests for GET /elo/history Summary
+
+**Sealed ELO-API-01 with 5 integration tests covering the four ROADMAP success criteria plus a defensive timezone regression. Full backend suite went from 176 → 181 passed — exactly +5, zero regressions, `test_elo_cascade.py` byte-identical to its pre-plan state.**
+
+## Performance
+
+- **Duration:** ~3 min
+- **Started:** 2026-04-29T02:37:30Z
+- **Completed:** 2026-04-29T02:40:15Z
+- **Tasks:** 1 (single composite task creating both files)
+- **Files modified:** 2 (both created)
+
+## Accomplishments
+
+- `backend/tests/integration/_elo_helpers.py` created (54 lines including module docstring) with the 5 shared helpers (`_player_result`, `_pr`, `_game_payload`, `_post_game`, `_CORP_BY_PLAYER`) extracted byte-for-byte from `test_elo_cascade.py`. No `fastapi`, `main`, or `pytest` imports — pure data-shape helpers + the `_post_game` HTTP wrapper that takes `client` as an argument.
+- `backend/tests/integration/test_elo_routes.py` created (197 lines) with 5 tests, each named exactly per acceptance criteria, covering ELO-API-01's full surface.
+- Full Docker test suite green: **181 passed, 0 failed in 1.64s** (was 176 in Plan 03 — exactly +5 new tests).
+- `test_elo_cascade.py` byte-identical to its pre-plan state (`git diff backend/tests/integration/test_elo_cascade.py` returned empty after the commit).
+- ELO-API-01 marked complete in `REQUIREMENTS.md` (the Phase 8 closer).
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create _elo_helpers.py + test_elo_routes.py** — `3a81dce` (test)
+
+**Plan metadata commit:** pending (final commit will include this SUMMARY + STATE.md + ROADMAP.md + REQUIREMENTS.md).
+
+## Files Created/Modified
+
+- `backend/tests/integration/_elo_helpers.py` — created (5 helpers + module docstring; no test functions, no fixtures, no app imports).
+- `backend/tests/integration/test_elo_routes.py` — created (5 test functions + 2 file-local fixtures + 2 file-local seed helpers).
+
+### The five test names and the success criterion each covers
+
+| # | Test name | ROADMAP SC |
+|---|-----------|------------|
+| 1 | `test_history_no_filters_returns_active_players_with_points` | SC-1: default = active players, non-empty points covering all recorded games |
+| 2 | `test_history_from_filter_drops_earlier_points_in_non_utc_tz` | SC-2: `?from=YYYY-MM-DD` returns only points with `recorded_at >= from`, no off-by-one drift in non-UTC TZ (defensive — see test docstring) |
+| 3 | `test_history_player_ids_filter_drops_unknown_ids_silently` | SC-3: mix of valid + unknown ids returns only valid; HTTP 200 (not 400/422) |
+| 4 | `test_history_invalid_from_returns_422` | SC-4a: invalid `from` value triggers FastAPI auto-422 |
+| 5 | `test_history_response_shape_matches_player_elo_history_dto` | SC-4b: response field-for-field matches `PlayerEloHistoryDTO` (including `recorded_at` as YYYY-MM-DD string) |
+
+### Final content of `backend/tests/integration/_elo_helpers.py`
+
+```python
+"""
+Shared helpers for ELO integration tests.
+
+Extracted from test_elo_cascade.py per CLAUDE.md §3 (no code duplication).
+Used by test_elo_routes.py (Phase 8). The original copies in test_elo_cascade.py
+remain in place — consolidating that file is OUT OF SCOPE for Phase 8.
+
+The leading underscore marks this module as test-internal. Pytest does NOT
+collect modules whose name starts with `_`, so this file is not a test file.
+"""
+
+
+def _player_result(player_id: str, terraform_rating: int, corp: str = "Credicor") -> dict:
+    return {
+        "player_id": player_id,
+        "corporation": corp,
+        "scores": {
+            "terraform_rating": terraform_rating,
+            "milestone_points": 0,
+            "milestones": [],
+            "award_points": 0,
+            "card_points": 0,
+            "card_resource_points": 0,
+            "greenery_points": 0,
+            "city_points": 0,
+            "turmoil_points": None,
+        },
+        "end_stats": {"mc_total": 0},
+    }
+
+
+_CORP_BY_PLAYER = {"p1": "Credicor", "p2": "Ecoline", "p3": "Helion"}
+
+
+def _pr(player_id: str, terraform_rating: int) -> dict:
+    return _player_result(player_id, terraform_rating, _CORP_BY_PLAYER[player_id])
+
+
+def _game_payload(game_id: str, on_date: str, results: list[dict]) -> dict:
+    return {
+        "id": game_id,
+        "date": on_date,
+        "map": "Hellas",
+        "expansions": [],
+        "draft": False,
+        "generations": 10,
+        "player_results": results,
+        "awards": [],
+    }
+
+
+def _post_game(client, payload: dict) -> str:
+    res = client.post("/games/", json=payload)
+    assert res.status_code == 200, res.json()
+    return res.json()["id"]
+```
+
+This is the canonical reference for a future cleanup phase that consolidates `test_elo_cascade.py`: a parity diff between the helper bodies in `_elo_helpers.py` and the inlined copies in `test_elo_cascade.py` (lines 33–76) should be byte-identical (modulo the surrounding blank-line conventions). When that cleanup phase runs, replacing the inlined copies with `from _elo_helpers import ...` is safe because both files now share the same source of truth.
+
+### Test suite output (post-task `make test-backend`)
+
+```
+INFO  [alembic.runtime.migration] Running upgrade f3a9b2c1d4e5 -> b8d4e2c5a7f1, add elo system
+........................................................................ [ 39%]
+........................................................................ [ 79%]
+.....................................                                    [100%]
+181 passed in 1.64s
+```
+
+**181 passed, 0 failed** — exactly +5 over Plan 03's 176 baseline. The Makefile recipe runs the WHOLE backend suite (no `ARGS`, no per-file selection); the 5 new tests are necessarily included in the count, and the absence of any `F`/`E` in the dot string proves all 5 PASSED. Per-file verbose output is not available because the docker-compose entrypoint is hardcoded to `python -m pytest tests -q`.
+
+### Pre-existing test_elo_cascade.py untouched (regression check)
+
+```
+$ git diff backend/tests/integration/test_elo_cascade.py
+$ # (empty diff — file is byte-identical to its pre-plan state)
+```
+
+Confirms scope discipline: the inline helpers in `test_elo_cascade.py` stay in place; consolidating that file is left as a future cleanup phase.
+
+### CLAUDE.md compliance
+
+- **§3 (no duplicar código):** Phase 8 introduced ZERO new duplication. The 5 helpers are defined exactly once (in `_elo_helpers.py`) and consumed by `test_elo_routes.py` via absolute import. The pre-existing inline copies in `test_elo_cascade.py` were left intact (decoupled scope), but `_elo_helpers.py` now exists to enable a future cleanup phase to remove that older duplication safely.
+- **§3 (refactor if function >20 lines):** All test functions are well under 20 lines (largest is `test_history_no_filters_returns_active_players_with_points` at ~17 lines including blank lines). Test-local seed helpers (`_seed_three_active_players`, `_seed_two_games`) are 4 and 9 lines respectively.
+- **§3 (separar lógica y presentación):** Tests assert against the HTTP wire shape (`res.json()`); they do not poke at service internals or repository state directly. The shape check (`set(point.keys()) == {...}`) treats the DTO as a black-box contract.
+- **§3 (actualizar archivos de documentación .md):** This SUMMARY documents the new test surface and unblocks Phases 9, 11, 12 with a frozen contract reference. STATE.md and REQUIREMENTS.md are updated below.
+- **memory: feedback_never_run_pytest_locally:** Used `make test-backend` (Docker) — never `pytest` on host. Confirmed via the Makefile recipe (`docker compose -f docker-compose.test.yml run --rm --build backend_test`) which mounts the test DB only.
+
+## Decisions Made
+
+- **Helper import form:** Absolute (`from _elo_helpers import ...`) rather than relative. The plan acknowledged both forms; reading the directory layout confirmed `backend/tests/integration/` has NO `__init__.py`, so the relative form (`from ._elo_helpers import ...`) would fail. The absolute form works because pytest's rootdir-based collection prepends the test file's directory to `sys.path`, and the `_elo_helpers.py` underscore prefix prevents pytest from trying to collect it as a test module.
+- All other choices were locked upstream in CONTEXT (D-02, D-03, D-04), PATTERNS (`backend/tests/integration/test_elo_routes.py` section), and the 08-04-PLAN itself.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No Rule 1/2/3/4 deviations triggered. The "absolute vs relative import" choice was pre-authorized by the plan ("if it is NOT a package, fall back to `from _elo_helpers import ...`").
+
+## Issues Encountered
+
+None. The task had explicit pre-existing analogs (`test_elo_cascade.py` for the helper bodies and fixture wiring; `test_achievements_routes.py` for the route-level integration shape), zero ambiguity, no auth gates, no architectural questions. The defensive scope of the TZ test is explicitly documented in its docstring per the plan's WARNING-1 requirement.
+
+## User Setup Required
+
+None — pure test code, no env vars, no service config, no migrations. The Docker test DB is wiped/migrated fresh on every `make test-backend` invocation.
+
+## Threat Flags
+
+None. The new files are read-only test code that only exercises the existing `GET /elo/history` endpoint over an in-process `TestClient`. No new network surface, no auth path, no file I/O, no schema change, no new dependency.
+
+## Requirements Status
+
+`ELO-API-01` is now **Complete** — Phase 8's contractual seal: the four ROADMAP success criteria plus the defensive TZ regression are sealed by automated tests. The `requirements mark-complete ELO-API-01` invocation succeeded:
+
+```
+{
+  "updated": true,
+  "marked_complete": ["ELO-API-01"],
+  "already_complete": [],
+  "not_found": [],
+  "total": 1
+}
+```
+
+## Next Phase Readiness
+
+- **ELO-API-01 closed.** Phase 8 is complete (from the plan-execution perspective). Whether the phase is marked Complete in ROADMAP.md is up to the orchestrator/verifier per the plan's critical rules ("DO NOT mark phase complete in ROADMAP — orchestrator handles that after verification").
+- **Wire contract is now sealed by tests, not just promises.** Phases 09 (frontend ELO types — `src/types/index.ts`), 11 (Ranking page), and 12 (chart) MUST consume `PlayerEloHistoryDTO` field-for-field as the test asserts: top-level `{player_id, player_name, points}`; each point `{recorded_at, game_id, elo_after, delta}`; `recorded_at` is a YYYY-MM-DD string (never a datetime). Any future shape drift in the backend will fail `test_history_response_shape_matches_player_elo_history_dto`, catching the break before the frontend consumes it.
+- **Helper module ready for future use.** `_elo_helpers.py` exists as a shared utility. A future cleanup phase can replace the inline copies in `test_elo_cascade.py` with `from _elo_helpers import ...` to remove the older (Phase-1-era) duplication. Out of scope for Phase 8.
+- **No new dependencies.** All imports are stdlib (`time`) + already-installed `pytest` / `fastapi` / project modules.
+
+## Note for downstream phases
+
+This SUMMARY is the canonical reference for the locked `GET /elo/history` response shape. Phases 9, 11, 12 must consume:
+
+- **Top-level:** `list[{player_id: str, player_name: str, points: list[...]}]`
+- **Each point:** `{recorded_at: str (YYYY-MM-DD), game_id: str, elo_after: int, delta: int}`
+- **Order within points:** ascending by `(recorded_at, game_id)` — guaranteed by `EloRepository.get_history` order-by tuple
+- **Top-level player order:** ascending by `player_name` — implementation-only (Phase 12 chart assigns colors by id hash, not order)
+- **Empty-history players:** dropped from response (no `points: []` entries)
+- **Unknown ids in `?player_ids=`:** silently dropped (HTTP 200, not 400/422)
+- **Invalid `?from=`:** HTTP 422 (FastAPI auto-validation)
+
+## Note for a future cleanup phase
+
+`backend/tests/integration/test_elo_cascade.py` still has inline copies of the 5 helpers (lines 33–76). Consolidating that file by replacing the inline copies with `from _elo_helpers import ...` is a candidate refactor — out of scope for Phase 8, but `_elo_helpers.py` exists specifically to enable it. Parity check: a `diff` between `test_elo_cascade.py` lines 33–76 and `_elo_helpers.py` lines 13–53 should show only whitespace/blank-line differences.
+
+## Self-Check: PASSED
+
+- `backend/tests/integration/_elo_helpers.py` — FOUND (created)
+- `backend/tests/integration/test_elo_routes.py` — FOUND (created)
+- Commit `3a81dce` (Task 1) — FOUND in `git log` (`git log --oneline -5 | grep 3a81dce`)
+- All 5 test names present in `test_elo_routes.py` (verified via grep)
+- All 5 helper definitions present in `_elo_helpers.py` (verified via grep)
+- Zero helper definitions in `test_elo_routes.py` (verified via grep — the duplication check)
+- `make test-backend` exits 0 with 181 passed (was 176 in Plan 03 — exactly +5 new tests, zero regressions)
+- `test_elo_cascade.py` byte-identical (`git diff` empty)
+- ELO-API-01 marked Complete in REQUIREMENTS.md (gsd-tools `requirements mark-complete` returned `marked_complete: ["ELO-API-01"]`)
+
+---
+*Phase: 08-backend-get-elo-history-endpoint*
+*Completed: 2026-04-29*

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-CONTEXT.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-CONTEXT.md
@@ -1,0 +1,138 @@
+# Phase 8: Backend `GET /elo/history` endpoint - Context
+
+**Gathered:** 2026-04-28
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Add a new REST endpoint `GET /elo/history` that exposes the per-player ELO time series the v1.1 Ranking chart needs. Supports optional `from` (date) and `player_ids` filters. No frontend, no chart, no migration — repository data already exists via `PlayerEloHistory`. This phase ratifies the response shape that Phases 9–12 will consume.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Route placement
+- **D-01:** Endpoint lives in a new `backend/routes/elo_routes.py` with `prefix="/elo"`, `tags=["Elo"]`. Register the router in `backend/main.py` alongside the existing four routers (mirrors the `achievements_routes.py` pattern).
+- The existing `GET /games/{id}/elo` stays in `games_routes.py` (it is genuinely game-scoped). New per-player and cross-player ELO endpoints go under `/elo` going forward.
+
+### Response semantics
+- **D-02:** Players with zero points in the requested window are dropped from the response (no `points: []` entries). The default candidate set is "active players", but a player who is active and has no history in the window simply does not appear in the list. Frontend chart never has to handle empty series.
+- **D-03:** When the caller passes `player_ids`, it overrides the active filter — explicit opt-in. Inactive players named in `player_ids` ARE returned with their history. When `player_ids` is absent, the candidate set is "active players only". Unknown ids in `player_ids` are silently dropped (per ROADMAP success criterion 3).
+
+### Repository / filter shape
+- **D-04:** New `EloHistoryFilter` dataclass in `backend/repositories/elo_filters.py` with `date_from: Optional[date] = None` and `player_ids: Optional[set[str]] = None`. New `EloRepository.get_history(filter: EloHistoryFilter)` method does ONE indexed query against `player_elo_history` (the existing `recorded_at` index covers the `from` filter; `player_id` is also indexed). Filter capabilities live on the dataclass — service does NOT reimplement filter logic.
+- Service orchestration: `EloService.get_history(date_from, player_ids)` resolves the candidate player set (active players from `PlayersRepository.get_all()` filtered by `is_active`, OR explicitly named players when `player_ids` is passed), builds the `EloHistoryFilter`, calls the repo, groups rows by `player_id`, and maps to `list[PlayerEloHistoryDTO]`.
+
+### Route validation
+- `from` is parsed as `date` via FastAPI's built-in `Query` type-coercion (`from_: Optional[date] = Query(None, alias="from")`). Invalid format triggers FastAPI's automatic 422 response — no custom validator needed.
+- `player_ids` is parsed as comma-separated string via `Query` (e.g. `player_ids=p1,p2`), split server-side into a `set[str]`. Empty string and missing param both treated as "no filter".
+
+### Schemas (locks the contract for Phases 9–12)
+- Add `EloHistoryPointDTO { recorded_at: date, game_id: str, elo_after: int, delta: int }` to `backend/schemas/elo.py`.
+- Add `PlayerEloHistoryDTO { player_id: str, player_name: str, points: list[EloHistoryPointDTO] }` to the same file.
+- Existing `EloChangeDTO` is unchanged.
+- `recorded_at` serializes as `YYYY-MM-DD` string (Pydantic default for `date`); the frontend treats it as opaque per the timezone pitfall guidance in research.
+
+### Sorting / ordering
+- Points within a player are sorted ascending by `(recorded_at, game_id)` — same tuple the recompute walker uses, so re-runs and reads stay consistent.
+- Top-level player order is not contractual (frontend assigns colors by id hash, not order), but the implementation should sort by `player_name` for deterministic test fixtures.
+
+### Mappers
+- New `elo_history_changes_to_player_dto(player_id, player_name, history_rows)` in `backend/mappers/elo_mapper.py` (alongside the existing `elo_changes_to_dtos`). Reuses the same player-names-map pattern as `games_routes._player_names_map`.
+
+### Container wiring
+- `EloService` already exists in `services/container.py` with `elo_repository`, `players_repository`, `games_repository`. The new `get_history` method is added there — no new container entries needed.
+- The new route file imports `elo_service` from `services/container.py` (no per-request DI inversion).
+
+### Tests
+- Unit test the mapper and the service candidate-resolution logic (mock repos).
+- Integration tests in `backend/tests/integration/` covering the four ROADMAP success criteria: no filters → all active players, `from` filter, `player_ids` filter (incl. unknown ids silently dropped), invalid `from` → 422.
+- One test runs in `America/Argentina/Buenos_Aires` TZ to enforce no off-by-one drift (success criterion 2). All pytest runs go through `docker-compose.test.yml` per project rule.
+
+### Claude's Discretion
+- Exact name of the service method (`get_history` vs `list_player_history`)
+- Whether the route function destructures the service result inline or via mapper helper
+- Internal naming of `EloHistoryFilter` private fields
+- Test fixture builders (likely reuse existing `conftest.py` patterns)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase intent and success criteria
+- `.planning/ROADMAP.md` §"Phase 8: Backend GET /elo/history endpoint" — goal, depends-on, requirement mapping, 4 success criteria
+- `.planning/REQUIREMENTS.md` §ELO-API-01 — single requirement this phase fulfills
+- `.planning/PROJECT.md` §"Current Milestone: v1.1" — milestone framing and constraints
+
+### Research backing the contract
+- `.planning/research/SUMMARY.md` — milestone-wide research synthesis; §"Phase 0 — Backend GET /elo/history" defines the expected response shape; §"Gaps to Address" flags pagination as undecided (this phase resolves it: no pagination)
+- `.planning/research/ARCHITECTURE.md` — layered backend convention (route → service → repository → mapper)
+- `.planning/research/PITFALLS.md` — Pitfall 4 (date filter timezone shift) governs the non-UTC TZ test
+
+### Existing ELO backend (read before extending)
+- `backend/services/elo_service.py` — `EloService` constructor, `recompute_from_date`, `_build_baseline`; new `get_history` method goes here
+- `backend/repositories/elo_repository.py` — repo to extend with `get_history(filter)`; existing `get_baseline_elo_before` shows the indexed-query pattern
+- `backend/repositories/elo_filters.py` — DOES NOT YET EXIST; create alongside the new method (mirrors `repositories/game_filters.py`)
+- `backend/repositories/game_filters.py` — pattern reference for `EloHistoryFilter` dataclass (`@dataclass`, `Optional` fields)
+- `backend/schemas/elo.py` — `EloChangeDTO` already lives here; add `EloHistoryPointDTO` and `PlayerEloHistoryDTO` to the same file
+- `backend/mappers/elo_mapper.py` — `elo_changes_to_dtos` shows the player-names-map pattern to reuse
+- `backend/db/models.py` §`PlayerEloHistory` (lines 114–125) — ORM table; `recorded_at` and `player_id` are both indexed
+- `backend/routes/games_routes.py` — current `/games/{id}/elo` route + `_player_names_map` helper to imitate
+- `backend/routes/achievements_routes.py` — closest pattern for a new top-level routes file with its own prefix
+- `backend/main.py` — register the new `elo_router` here
+- `backend/services/container.py` — `EloService` is already wired with all needed repos; just extend the class
+- `backend/repositories/player_repository.py` — `get_all()` returns Player domain objects with `is_active` field used to derive the active set
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- **`EloRepository.get_baseline_elo_before(date)`** — proves the indexed query against `PlayerEloHistory.recorded_at` works; `get_history` follows the same shape but with optional player filter and returns rows instead of last-value baseline.
+- **`elo_changes_to_dtos` + `_player_names_map`** in `games_routes.py` — pattern for resolving `player_id → player_name` in one pass.
+- **`GameFilter`** — template for `EloHistoryFilter`'s structure (small `@dataclass` with `Optional` fields, lives next to the repo it serves).
+- **`PlayerEloHistory` ORM** — already has indexes on `recorded_at` AND `player_id`, so the combined filter is a single indexed scan with no schema change.
+- **`achievements_routes.py`** — closest precedent for "new top-level prefix" route file (achievements, like elo, isn't nested under players or games).
+
+### Established Patterns
+- Routes import service singletons from `services/container.py` (never instantiate per request).
+- Filter capabilities live on dataclasses (per project rule); services orchestrate, repositories execute the query, mappers convert ORM → DTO.
+- Pydantic DTOs use `BaseModel`, primitive types, no validators unless needed (FastAPI handles 422 on bad path/query types).
+- Tests for backend services use `docker-compose.test.yml` (NEVER pytest on host — project rule).
+
+### Integration Points
+- `backend/main.py` line 21–24 — add `app.include_router(elo_router)`.
+- `backend/services/container.py` — `EloService` instance is reused; new method just extends the class definition in `elo_service.py`.
+- Frontend Phase 9 will define `PlayerEloHistoryDTO` in `src/types/index.ts` to match this contract; success criterion 4 ties them together. Any shape change here ripples to D.2 plans, so this CONTEXT locks the shape.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The endpoint is a frontend-driven contract — every shape decision here is consumed by Phase 9 (`api/elo.ts`), Phase 11 (`Ranking` page filter wiring), and Phase 12 (chart). The chart Y-axis MUST key on `elo_after`, never `delta`, never a client-side running sum (per PITFALLS.md §11).
+- The `from` filter is opaque-string end-to-end on the frontend; backend parses it as `date` once via FastAPI Query coercion and never reformats. No `.toISOString()` anywhere.
+- Pagination is explicitly out: friend-group dataset, manual entry, expected order-of-magnitude is hundreds of points — single response is fine. If this stops being true, future-us adds a `limit`/`cursor` without breaking the current shape.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Leaderboard endpoint** — RANK-05 (current rank + last delta per player) is in Phase 12. The chart endpoint and the leaderboard could share data via a single `/elo/history` call (frontend computes rank from latest `elo_after`); if Phase 12 surfaces a need for a separate `/elo/leaderboard` endpoint, that is a new phase.
+- **Pagination / limit** — not added in v1.1; revisit if dataset grows.
+- **Per-game markers / events on the chart line** — coupled to deferred records redesign; not consumed by this endpoint.
+- **Peak rating endpoint** — Phase 9 (PROF-03) computes peak client-side from this endpoint's response; no separate route needed.
+
+</deferred>
+
+---
+
+*Phase: 08-backend-get-elo-history-endpoint*
+*Context gathered: 2026-04-28*

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-DISCUSSION-LOG.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-DISCUSSION-LOG.md
@@ -1,0 +1,76 @@
+# Phase 8: Backend `GET /elo/history` endpoint - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-28
+**Phase:** 08-backend-get-elo-history-endpoint
+**Areas discussed:** Route placement, Active-but-no-games players, player_ids vs active filter, Repository / filter shape
+
+---
+
+## Route placement
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New routes/elo_routes.py | Dedicated file for /elo prefix; future ELO endpoints (peak/rank/leaderboard) extend here. Mirrors achievements_routes.py. | ✓ |
+| Extend games_routes.py | Add to existing file that already has /games/{id}/elo, but /elo/history isn't game-scoped — prefix mismatch. | |
+| Extend players_routes.py | Players routes touch player.elo, but /elo/history isn't nested under /players/{id} — same prefix mismatch. | |
+
+**User's choice:** New routes/elo_routes.py
+**Notes:** Recommended option chosen — clean prefix, room for /elo to grow with future endpoints.
+
+---
+
+## Active-but-no-games players
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Drop them from response | Only return players with at least one point in the window. Cleaner contract, smaller payload, frontend never handles empty series. | ✓ |
+| Include with points: [] | Return every active player even with no history; frontend filters empty series. | |
+| Include with seeded 1000 baseline | Synthesize a point at today with elo_after=1000 — invents data the backend never recorded; conflicts with PROF-04 ("— not 1000 for 0-game players"). | |
+
+**User's choice:** Drop them from response
+**Notes:** Aligns with PROF-04 (0-games players show "—", not 1000) and removes a class of empty-state handling on the frontend.
+
+---
+
+## player_ids vs active filter
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| player_ids overrides active | Explicit player_ids = explicit opt-in; serves history regardless of active flag. Old shared URLs with deactivated players still render the chart. | ✓ |
+| Always intersect with active | Active filter wins; inactive players silently dropped even when named. Simpler invariant but two silent-drop reasons (unknown + inactive) frontend can't distinguish. | |
+| No active filter when player_ids passed | When player_ids is present, return whoever is named with no active scoping. | |
+
+**User's choice:** player_ids overrides active
+**Notes:** Lines up with RANK-06 frontend behavior — frontend already intersects URL ids against active before calling, so any inactive id reaching the backend is intentional.
+
+---
+
+## Repository / filter shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New EloHistoryFilter + repo.get_history(filter) | New dataclass in repositories/elo_filters.py; one indexed query against PlayerEloHistory; filter logic centralized on the dataclass per prior feedback. | ✓ |
+| Extend GameFilter, walk per-game in service | Reuses existing filter but does N queries and conflates two domains. | |
+| Add method with raw kwargs | EloRepository.get_history(date_from, player_ids) without dataclass — spreads filter shape across signatures. | |
+
+**User's choice:** New EloHistoryFilter + repo.get_history(filter)
+**Notes:** Honors the project rule "filter capabilities go on the existing/new filter dataclass; services don't reimplement filter logic". Single indexed scan instead of N per-game queries.
+
+---
+
+## Claude's Discretion
+
+- Exact name of the service method (`get_history` vs `list_player_history`)
+- Whether the route function destructures the service result inline or via mapper helper
+- Internal naming of `EloHistoryFilter` private fields
+- Test fixture builders (likely reuse existing `conftest.py` patterns)
+
+## Deferred Ideas
+
+- Leaderboard endpoint (Phase 12 may compute client-side from /elo/history; separate route only if surface need emerges)
+- Pagination / limit (revisit only if dataset grows beyond hundreds of points)
+- Per-game markers / events on chart line (coupled to deferred records redesign)
+- Peak rating endpoint (Phase 9 derives peak client-side from this response)

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-REVIEW.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-REVIEW.md
@@ -1,0 +1,191 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+reviewed: 2026-04-28T00:00:00Z
+depth: standard
+files_reviewed: 9
+files_reviewed_list:
+  - backend/main.py
+  - backend/mappers/elo_mapper.py
+  - backend/repositories/elo_filters.py
+  - backend/repositories/elo_repository.py
+  - backend/routes/elo_routes.py
+  - backend/schemas/elo.py
+  - backend/services/elo_service.py
+  - backend/tests/integration/_elo_helpers.py
+  - backend/tests/integration/test_elo_routes.py
+findings:
+  critical: 0
+  high: 0
+  medium: 1
+  low: 2
+  info: 4
+  total: 7
+status: needs-fixes
+---
+
+# Phase 8: Code Review Report
+
+**Reviewed:** 2026-04-28
+**Depth:** standard
+**Files Reviewed:** 9
+**Status:** needs-fixes
+
+## Summary
+
+The phase 8 implementation is small, well-scoped, and follows the established backend layering (route → service → repo → mapper). Every project rule from CLAUDE.md and the locked CONTEXT decisions was respected: the filter capability lives on `EloHistoryFilter` (no service-side reimplementation), `EloService.get_history` stays under the 20-line refactor threshold by extracting `_resolve_candidates`, container layering is clean, no try/except cruft was added to a read-only route, and `_elo_helpers.py` is the single source of truth for new helpers introduced by this phase.
+
+One real test-isolation bug exists (the TZ test calls `time.tzset()` without restoring it, leaking process state into subsequent tests). The remaining items are minor code-quality nits (shadowed builtin, dead `noqa` imports, unguarded empty-set behavior in the repository) and one already-acknowledged deferred duplication between `_elo_helpers.py` and `test_elo_cascade.py`.
+
+## Medium
+
+### MD-01: TZ test mutates global process TZ via `time.tzset()` without restoration
+
+**File:** `backend/tests/integration/test_elo_routes.py:126-128`
+
+**Issue:** `monkeypatch.setenv("TZ", "America/Argentina/Buenos_Aires")` is auto-restored by pytest at test teardown, but `time.tzset()` writes the new TZ into the libc tzname/timezone globals, and pytest does NOT call `tzset()` again after restoring `TZ`. After this test runs, the process keeps Buenos Aires as its effective TZ until another test happens to call `tzset()` or until the worker exits. If pytest reorders tests or a future test reads `time.localtime()` / `datetime.now()` (no `tz` arg) and asserts on the result, it will silently get the wrong day in CI.
+
+The risk is amplified because the test file's docstring openly admits the test is "defensive only" — the failure mode it would cause in sibling tests is exactly the kind of intermittent, order-dependent breakage that is hard to debug.
+
+**Fix:** Restore the libc TZ after the assertions, ideally via a fixture or a `try/finally`. Minimum viable fix:
+
+```python
+def test_history_from_filter_drops_earlier_points_in_non_utc_tz(monkeypatch, client, players_repo):
+    """..."""
+    monkeypatch.setenv("TZ", "America/Argentina/Buenos_Aires")
+    if hasattr(time, "tzset"):
+        time.tzset()
+    try:
+        _seed_three_active_players(players_repo)
+        _seed_two_games(client)
+
+        res = client.get("/elo/history?from=2026-02-15")
+        assert res.status_code == 200, res.json()
+        data = res.json()
+        assert data, "expected non-empty response under from=2026-02-15"
+
+        for entry in data:
+            for point in entry["points"]:
+                assert point["recorded_at"] >= "2026-02-15", point
+                assert point["game_id"] == "g-feb", point
+    finally:
+        # monkeypatch restores TZ env var, but libc state needs an explicit re-tzset.
+        if hasattr(time, "tzset"):
+            time.tzset()
+```
+
+A cleaner alternative is a small autouse fixture that snapshots and restores the libc TZ:
+
+```python
+@pytest.fixture
+def reset_libc_tz():
+    yield
+    if hasattr(time, "tzset"):
+        time.tzset()  # re-reads TZ env, which monkeypatch has already restored
+```
+
+## Low
+
+### LO-01: `EloRepository.get_history` parameter named `filter` shadows the Python builtin
+
+**File:** `backend/repositories/elo_repository.py:90`
+
+**Issue:** `def get_history(self, filter: EloHistoryFilter)` shadows the built-in `filter()`. While the body of this method does not call `filter()`, shadowing builtins is a recognized smell — most linters flag it (`builtin-argument-shadowing` / `A002`) and it complicates future edits that might want to use the builtin inside the method.
+
+**Fix:** Rename the parameter (and update the one call site in `EloService.get_history`):
+
+```python
+def get_history(self, history_filter: EloHistoryFilter) -> list[PlayerEloHistoryORM]:
+    with self._session_factory() as session:
+        query = session.query(PlayerEloHistoryORM)
+        if history_filter.date_from is not None:
+            query = query.filter(PlayerEloHistoryORM.recorded_at >= history_filter.date_from)
+        if history_filter.player_ids is not None:
+            query = query.filter(PlayerEloHistoryORM.player_id.in_(history_filter.player_ids))
+        ...
+```
+
+(Note that `GameFilter` is consumed by `GamesRepository.list_games(self, filters: Optional[GameFilter] = None)` — the existing convention in the codebase uses `filters`, plural, not `filter`. Aligning with that convention also resolves the shadowing.)
+
+### LO-02: `EloRepository.get_history` issues `WHERE player_id IN ()` if called with an empty `player_ids` set
+
+**File:** `backend/repositories/elo_repository.py:100-101`
+
+**Issue:** The repo branches on `if filter.player_ids is not None`, so an empty set (`set()`) takes the filter branch and produces `PlayerEloHistoryORM.player_id.in_(set())`. SQLAlchemy emits a "SAWarning: empty in_ predicate" and rewrites it to a `1 != 1` clause — functionally fine (returns no rows) but noisy in test output and a footgun for future callers.
+
+The current service short-circuits to `[]` before invoking the repo when `candidate_ids` is empty, so this never fires today. But the repository method is a reusable surface and should defend itself rather than rely on caller discipline.
+
+**Fix:** Either skip the filter branch on empty set, or short-circuit the whole query:
+
+```python
+if filter.player_ids is not None and len(filter.player_ids) > 0:
+    query = query.filter(PlayerEloHistoryORM.player_id.in_(filter.player_ids))
+```
+
+Or, more strictly (treat empty set as "no candidates" and return early):
+
+```python
+if filter.player_ids is not None:
+    if not filter.player_ids:
+        return []
+    query = query.filter(PlayerEloHistoryORM.player_id.in_(filter.player_ids))
+```
+
+The first form is the safer behavioral match (empty set still means "no filter restriction," consistent with the semantics on the `Optional` field — it is the caller's contract that `None` means "no filter," and an empty set arguably means "no candidates," so the second form is a stronger guarantee but is a contract change). Pick whichever fits the intended semantics; the SAWarning needs to go either way.
+
+## Info
+
+### IN-01: Unused `noqa: F401` re-exports in `test_elo_routes.py`
+
+**File:** `backend/tests/integration/test_elo_routes.py:28-34`
+
+**Issue:** `_CORP_BY_PLAYER` and `_player_result` are imported and silenced with `# noqa: F401  (re-exported for completeness; safe to drop if unused)`. The comment itself acknowledges they are unused. Importing for "completeness" is cargo-cult — these symbols are not part of any public API of this test module, and the underscore prefix already signals private intent.
+
+**Fix:** Drop the two unused imports; leave only `_game_payload`, `_post_game`, and `_pr`:
+
+```python
+from _elo_helpers import (
+    _game_payload,
+    _post_game,
+    _pr,
+)
+```
+
+### IN-02: Helpers in `_elo_helpers.py` and `test_elo_cascade.py` are byte-duplicated (already acknowledged, track follow-up)
+
+**File:** `backend/tests/integration/_elo_helpers.py` (and `backend/tests/integration/test_elo_cascade.py:33-76`)
+
+**Issue:** Plan 04's SUMMARY explicitly notes that the five helpers extracted into `_elo_helpers.py` are still inlined verbatim in `test_elo_cascade.py`, and that consolidating them is "out of scope for Phase 8." This duplication directly violates CLAUDE.md §3 ("No duplicar código") — the rule is satisfied locally for Phase 8 (the new file imports from the helper module) but globally violated across the test directory.
+
+This is informational only because Phase 8's scope was to introduce `_elo_helpers.py`, not consolidate `test_elo_cascade.py`. It should be tracked as a follow-up cleanup task.
+
+**Fix:** Open a follow-up cleanup task (not part of this phase) to replace the inline helpers in `test_elo_cascade.py` with `from _elo_helpers import _CORP_BY_PLAYER, _game_payload, _player_result, _post_game, _pr` and re-run the cascade suite for parity. Per the SUMMARY, the bodies should already be byte-identical.
+
+### IN-03: Mixing PEP 585 (`set[str]`, `list[...]`, `dict[...]`) with `typing.Optional` is stylistically inconsistent
+
+**File:** `backend/repositories/elo_filters.py:3,9`; `backend/services/elo_service.py:2,123-124,158`; `backend/routes/elo_routes.py:2,15-16,18`
+
+**Issue:** The project targets a Python version that supports PEP 585 generics (`set[str]`, `list[PlayerEloHistoryDTO]`, `dict[str, int]` are used freely), and PEP 604 union syntax (`X | None`) is available from 3.10. Mixing `typing.Optional[X]` with `set[str]` reads as transitional code. Since the rest of the codebase uses the same mix (e.g., `game_filters.py` does it too), this is a consistency issue, not a bug, and aligning with existing convention is fine.
+
+**Fix:** No change required — the existing convention in this repo is the mix, and following it is correct. Flagging only so a future "modernize typing" sweep can address all files at once.
+
+### IN-04: Mapper module imports both an ORM type and an unrelated domain type that future edits could confuse
+
+**File:** `backend/mappers/elo_mapper.py:1-3`
+
+**Issue:** The mapper now imports `PlayerEloHistory as PlayerEloHistoryORM` (ORM row), `EloChange` (domain object), and three Pydantic DTOs. Two distinct mapper functions consume two distinct row shapes — `elo_change_to_dto` consumes `EloChange` (domain), and `elo_history_changes_to_player_dto` consumes `PlayerEloHistoryORM` (raw ORM). This works, but the naming asymmetry (one mapper takes a domain object, the other takes an ORM row directly) means a future reader could plausibly try to pass an `EloChange` to the new mapper, get an `AttributeError` on `r.recorded_at`, and not know why.
+
+The reason for the asymmetry is locked in Plan 02's key-decision ("Repository returns raw ORM rows ... avoids an intermediate domain object that would duplicate the schema fields"). This is a reasonable trade-off, but the type hint `list[PlayerEloHistoryORM]` is the only signal — there is no narrative comment explaining why the input shape differs from the sibling mapper's.
+
+**Fix:** No code change required; consider a one-line clarifying comment above `elo_history_changes_to_player_dto`, e.g.:
+
+```python
+# Note: takes raw ORM rows (NOT a domain object) — see Plan 02 D-01 for
+# the rationale (avoids a 4-field intermediate domain class that would
+# only mirror EloHistoryPointDTO).
+```
+
+---
+
+_Reviewed: 2026-04-28_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/08-backend-get-elo-history-endpoint/08-VERIFICATION.md
+++ b/.planning/phases/08-backend-get-elo-history-endpoint/08-VERIFICATION.md
@@ -1,0 +1,128 @@
+---
+phase: 08-backend-get-elo-history-endpoint
+verified: 2026-04-28T00:00:00Z
+status: passed
+score: 4/4 success criteria verified
+overrides_applied: 0
+re_verification: null
+gaps: []
+deferred: []
+human_verification: []
+---
+
+# Phase 8: Backend `GET /elo/history` Endpoint Verification Report
+
+**Phase Goal:** API exposes the per-player ELO time series the Ranking chart needs, with date and player filters
+**Verified:** 2026-04-28
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+The phase goal is fully achieved. All four ROADMAP success criteria for ELO-API-01 are implemented in the codebase with a direct, asserting test for each criterion. The full backend test suite (181 tests) has been confirmed green by Plan 04 — 5 new tests added on top of the 176-test Plan 03 baseline, zero regressions. The endpoint `/elo/history` is registered on the live FastAPI app (verified by direct import of `backend.main:app` and inspection of `app.routes`).
+
+### Observable Truths (mapped to ROADMAP Success Criteria)
+
+| # | Truth (Success Criterion) | Status | Evidence |
+|---|---------------------------|--------|----------|
+| 1 | `GET /elo/history` (no filters) returns one entry per active player with `points: [{recorded_at, game_id, elo_after, delta}, ...]` covering all recorded games | VERIFIED | `test_history_no_filters_returns_active_players_with_points` in `backend/tests/integration/test_elo_routes.py:70-90` asserts `ids == {p1, p2, p3}`, `len(entry["points"]) == 2` for each player, `game_ids == {g-jan, g-feb}`, AND `names == {p1: Alice, p2: Bob, p3: Cara}`. Implementation: `EloService._resolve_candidates` (`elo_service.py:156-173`) defaults to `is_active == True` players when `player_ids is None`. `get_history` (`elo_service.py:121-154`) drops empty-history players via `sorted(rows_by_player.keys(), ...)` (only players that produced rows are included). |
+| 2 | `GET /elo/history?from=YYYY-MM-DD` returns only points with `recorded_at >= from`, no off-by-one drift in non-UTC TZ | VERIFIED | `test_history_from_filter_drops_earlier_points_in_non_utc_tz` in `test_elo_routes.py:95-145` runs under `TZ=America/Argentina/Buenos_Aires` (`monkeypatch.setenv` + `time.tzset()`), asserts every returned `point["recorded_at"] >= "2026-02-15"` and `point["game_id"] == "g-feb"` after `?from=2026-02-15`. Implementation: `EloRepository.get_history` (`elo_repository.py:90-107`) uses `>=` (inclusive lower bound) on the indexed `recorded_at` column. Test docstring explicitly documents this is a defensive-regression guard (TZ env can't influence backend's TZ-naive `Date` column + Pydantic `date` serializer); the inclusive-bound half IS reproducible against the current backend. |
+| 3 | `GET /elo/history?player_ids=id1,id2` filters response; unknown ids silently dropped (NOT 400) | VERIFIED | `test_history_player_ids_filter_drops_unknown_ids_silently` in `test_elo_routes.py:150-160` calls `/elo/history?player_ids=p1,does-not-exist` and asserts `res.status_code == 200` AND `ids == {"p1"}`. Implementation: `EloService._resolve_candidates` (`elo_service.py:172`) filters `{pid for pid in player_ids if pid in names_by_id}` — unknown ids drop without raising. Route layer (`elo_routes.py:18-21`) splits the comma-separated query string into a `set[str]`. |
+| 4a | Invalid `from` (not YYYY-MM-DD) → 422 | VERIFIED | `test_history_invalid_from_returns_422` in `test_elo_routes.py:165-170` calls `/elo/history?from=not-a-date` and asserts `res.status_code == 422`. Implementation: `elo_routes.py:15` types `from_: Optional[date] = Query(None, alias="from")` — FastAPI's automatic Pydantic coercion produces 422 on parse failure, no custom validator. |
+| 4b | Response shape documented in `backend/schemas/elo.py` and matches frontend `PlayerEloHistoryDTO` | VERIFIED | `test_history_response_shape_matches_player_elo_history_dto` in `test_elo_routes.py:173-196` asserts `set(entry.keys()) == {"player_id", "player_name", "points"}` AND for each point `set(point.keys()) == {"recorded_at", "game_id", "elo_after", "delta"}`, `recorded_at` is a 10-char `YYYY-MM-DD` string, all field types are checked. Implementation: `backend/schemas/elo.py:14-24` defines `EloHistoryPointDTO` (recorded_at, game_id, elo_after, delta) and `PlayerEloHistoryDTO` (player_id, player_name, points). `recorded_at: date` → Pydantic default serialization is `YYYY-MM-DD`. |
+
+**Score:** 4/4 ROADMAP success criteria verified (5/5 if SC-4 is split into 4a + 4b — both halves covered).
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `backend/schemas/elo.py` | Defines `EloHistoryPointDTO` and `PlayerEloHistoryDTO`, preserves existing `EloChangeDTO` | VERIFIED | All three classes present (lines 6, 14, 21). `recorded_at: date`, points list typed correctly. `EloChangeDTO` byte-identical to pre-phase state. |
+| `backend/repositories/elo_filters.py` | `EloHistoryFilter` dataclass with `date_from` and `player_ids` only | VERIFIED | 9-line file (matches `game_filters.py` shape). Both fields `Optional[...] = None`. No extra fields, no methods. |
+| `backend/repositories/elo_repository.py` | `EloRepository.get_history(filter)` issues ONE indexed query, ordered by `(player_id, recorded_at, game_id)` | VERIFIED | Method at `elo_repository.py:90-107`. Single `session.query(PlayerEloHistoryORM)` with optional `>=` on `recorded_at` and `.in_()` on `player_id`. Order tuple matches `get_baseline_elo_before` and `_walk_and_persist` (preserves byte-consistency between reads and recomputes). |
+| `backend/mappers/elo_mapper.py` | `elo_history_changes_to_player_dto(player_id, player_name, history_rows)` is a pure transformation | VERIFIED | Function at `elo_mapper.py:26-50`. No I/O, no sorting, no filtering — only a list comprehension wrapping ORM rows in `EloHistoryPointDTO`. Existing functions (`elo_change_to_dto`, `elo_changes_to_dtos`) still present and unchanged. |
+| `backend/services/elo_service.py` | `EloService.get_history(date_from, player_ids)` → `list[PlayerEloHistoryDTO]` | VERIFIED | Public method at `elo_service.py:121-154` plus private helper `_resolve_candidates` at lines 156-173. Public method 19 statement lines (compliant with CLAUDE.md §3 ≤20 line rule). All six branching behaviors verified by Plan 03's in-process fake-repo test. |
+| `backend/routes/elo_routes.py` | `router = APIRouter(prefix="/elo", tags=["Elo"])` exposing `GET /history` | VERIFIED | Full file matches Plan 03 spec exactly. `from_: Optional[date] = Query(None, alias="from")` for FastAPI auto-422; `player_ids: Optional[str] = Query(None)` parsed into `set[str]` server-side. No try/except, no HTTPException. |
+| `backend/main.py` | `elo_router` imported and registered alongside the existing four routers | VERIFIED | Import at line 8, `app.include_router(elo_router)` at line 26. Pre-existing FastAPI app, CORS middleware, and four router registrations untouched. |
+| `backend/tests/integration/_elo_helpers.py` | Shared helpers extracted byte-for-byte from `test_elo_cascade.py` | VERIFIED | All 5 helpers (`_player_result`, `_pr`, `_game_payload`, `_post_game`, `_CORP_BY_PLAYER`) present (lines 13, 32, 35, 39, 52). Underscore prefix prevents pytest from collecting it as a test file. No `fastapi`/`main`/`pytest` imports. |
+| `backend/tests/integration/test_elo_routes.py` | 5 tests covering ROADMAP success criteria | VERIFIED | All 5 named test functions present (`grep -c "def test_history"` returns 5). Imports helpers from `_elo_helpers` (no inline duplication). Uses `TestClient(app)` per project convention. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|----|--------|---------|
+| `backend/routes/elo_routes.py` | `backend/services/container.elo_service` | `from services.container import elo_service` | WIRED | Line 7. Singleton import (per project rule `feedback_container_per_layer`). |
+| `backend/routes/elo_routes.py` | `EloService.get_history` | `elo_service.get_history(date_from=from_, player_ids=ids_set)` | WIRED | Line 21. Direct call with primitives. |
+| `backend/services/elo_service.py` | `EloRepository.get_history` | `self.elo_repository.get_history(EloHistoryFilter(...))` | WIRED | Lines 139-141. Constructs filter dataclass and calls repo. |
+| `backend/services/elo_service.py` | `elo_history_changes_to_player_dto` | Import at line 4, called once per player group at lines 148-152 | WIRED | Service groups rows by `r.player_id` then maps each group via the helper. |
+| `backend/services/elo_service.py` | `PlayersRepository.get_all` | `_resolve_candidates` calls `self.players_repository.get_all()` | WIRED | Line 167. Single pass yields both candidate set and id→name map. |
+| `backend/repositories/elo_repository.py` | `PlayerEloHistoryORM` | `session.query(PlayerEloHistoryORM)` | WIRED | Line 97. Indexed scan against `recorded_at` and `player_id` (both `index=True` per `db/models.py:114-125`). |
+| `backend/main.py` | `routes.elo_routes.router` | `from routes.elo_routes import router as elo_router` + `app.include_router(elo_router)` | WIRED | Lines 8, 26. Confirmed by direct import — `/elo/history` appears in `app.routes`. |
+| `backend/tests/integration/test_elo_routes.py` | `_elo_helpers` | `from _elo_helpers import (...)` | WIRED | Lines 28-34. Absolute import (works because integration/ has no `__init__.py` and pytest's rootdir-based collection prepends the test file's directory to `sys.path`). |
+| `backend/tests/integration/test_elo_routes.py` | `backend.main:app` via `TestClient` | `TestClient(app)` fixture | WIRED | Line 39. All 5 tests fire HTTP calls against this in-process client. |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|----------|---------------|--------|--------------------|--------|
+| `GET /elo/history` response | `list[PlayerEloHistoryDTO]` | `elo_service.get_history` → `EloRepository.get_history` → `session.query(PlayerEloHistoryORM)` (real Postgres query) | Yes — exercised by `test_history_no_filters_returns_active_players_with_points` which seeds 3 players + 2 games and asserts `len(entry["points"]) == 2` for each player | FLOWING |
+| `EloService.get_history` candidate set | `candidate_ids` | `PlayersRepository.get_all()` (real Postgres query) | Yes — exercised by `_seed_three_active_players` which creates real players via `players_repo.create(...)` | FLOWING |
+
+No HOLLOW or DISCONNECTED artifacts. The endpoint genuinely reads real ORM rows from a real Postgres DB inside Docker.
+
+### Behavioral Spot-Checks
+
+Skipped per task constraint: integration tests have already been run via `make test-backend` and confirmed passing (181 passed, 0 failed in 1.64s) — that is authoritative test evidence, no need to re-execute. Direct in-process import of `backend.main:app` confirms `/elo/history` is registered:
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| FastAPI app exposes `/elo/history` | `python -c "from main import app; print([r.path for r in app.routes if '/elo' in r.path])"` (run from `backend/`) | `['/games/{game_id}/elo', '/elo/history']` | PASS |
+| 5 `test_history_*` functions present | `grep -c "def test_history" backend/tests/integration/test_elo_routes.py` | 5 | PASS |
+| Test suite passes (Plan 04 evidence) | Plan 04 SUMMARY: `make test-backend` → "181 passed in 1.64s" (was 176 in Plan 03; exactly +5 new tests, 0 regressions) | 181 PASSED | PASS (authoritative — see Plan 04 SUMMARY lines 154-164) |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| ELO-API-01 | 08-01-PLAN, 08-02-PLAN, 08-03-PLAN, 08-04-PLAN | API expone `GET /elo/history` con filtros opcionales `from` (fecha) y `player_ids` (lista), devolviendo serie temporal de ELO por jugador para alimentar el chart de Ranking | SATISFIED | All 4 ROADMAP success criteria implemented and asserted by integration tests. `REQUIREMENTS.md` line 12 has `[x]` checkbox — `requirements mark-complete ELO-API-01` confirmed by Plan 04 SUMMARY (`marked_complete: ["ELO-API-01"]`). |
+
+No orphaned requirements: ELO-API-01 is the only requirement mapped to Phase 8 in REQUIREMENTS.md (line 69 / line 12), and all four plans declared it.
+
+### Anti-Patterns Found
+
+No anti-patterns in production code. `grep -nE "TODO|FIXME|XXX|HACK|PLACEHOLDER"` returned zero matches across all 6 production files (`elo.py`, `elo_filters.py`, `elo_repository.py`, `elo_mapper.py`, `elo_service.py`, `elo_routes.py`). No empty handlers, no static-return route stubs, no orphan state.
+
+### Known Issues (from Plan 04 code review — advisory, do not block verification)
+
+These were flagged in `08-REVIEW.md` and are intentionally surfaced here for the developer's awareness but do NOT gate phase verification (per `/gsd-code-review-fix` workflow, they get fixed in a follow-up commit):
+
+| ID | Severity | File | Issue | Fix path |
+|----|----------|------|-------|---------|
+| MD-01 | Medium | `test_elo_routes.py:126-128` | TZ test calls `time.tzset()` without restoration — leaks libc TZ state into subsequent tests; could cause intermittent CI failures if pytest reorders | Wrap assertions in `try/finally` and call `time.tzset()` in `finally` (monkeypatch already restores `TZ` env var, libc just needs a re-read). Or extract a small autouse fixture. |
+| LO-01 | Low | `elo_repository.py:90` | `def get_history(self, filter: ...)` shadows Python builtin `filter()`. Codebase convention elsewhere (`game_filters.py` callers) uses `filters` (plural). | Rename to `history_filter` or `filters` and update the one call site in `elo_service.py:139`. |
+| LO-02 | Low | `elo_repository.py:100-101` | If called directly with `player_ids=set()` the repo emits `WHERE player_id IN ()` → SQLAlchemy `SAWarning` + rewritten to `1 != 1`. Currently masked by the service's empty-set short-circuit (`get_history` returns `[]` before invoking the repo). | Add `and len(filter.player_ids) > 0` guard to the filter branch, OR short-circuit to `return []` when the set is empty. |
+
+These three issues are real but are post-merge polish, not gate-blocking. `/gsd-code-review-fix` is the canonical follow-up workflow.
+
+Documentation drift (informational only): `REQUIREMENTS.md` line 69's traceability table still shows `ELO-API-01 | Phase 8 | In Progress` while line 12 already has `[x]`. The implementation is complete; the table just needs to be updated to "Complete" at next ROADMAP/REQUIREMENTS sync.
+
+### Human Verification Required
+
+None. Backend-only phase: all four success criteria are programmatically asserted by integration tests that have already passed under Docker (`make test-backend` → 181 passed, 0 failed). No UI behavior, no real-time interaction, no external service integration involved. The TZ-Argentina assertion is the only behavior that historically warrants human verification, and it is sealed by `test_history_from_filter_drops_earlier_points_in_non_utc_tz` running under `monkeypatch.setenv("TZ", "America/Argentina/Buenos_Aires")` — automated.
+
+### Gaps Summary
+
+No gaps. The phase ships exactly what the ROADMAP success criteria specify:
+
+1. The endpoint is reachable on `http://localhost:8000/elo/history` (confirmed by `app.routes` inspection).
+2. All four success criteria + the defensive TZ regression are sealed by 5 named integration tests, each asserting the specific behavior the criterion calls out.
+3. The wire contract (`PlayerEloHistoryDTO` field-for-field) is locked in `backend/schemas/elo.py` and asserted by `test_history_response_shape_matches_player_elo_history_dto` — Phases 9, 11, 12 can consume it verbatim without surprise.
+4. No regressions: full suite went 176 → 181 (exactly +5 new tests, 0 failures).
+5. Implementation respects every CLAUDE.md / project-memory rule that applies (filter-on-dataclass, container-per-layer, no helper duplication introduced by this phase, `make test-backend` for all runs, ≤20-line functions via `_resolve_candidates` split).
+
+The only post-phase actions are the three advisory code-review items (MD-01, LO-01, LO-02) and the REQUIREMENTS.md traceability table line 69 update — none of which gate Phase 8.
+
+---
+
+_Verified: 2026-04-28_
+_Verifier: Claude (gsd-verifier)_

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from routes.games_routes import router as games_router
 from routes.players_routes import router as players_router
 from routes.records_routes import router as records_router
 from routes.achievements_routes import router as achievements_router
+from routes.elo_routes import router as elo_router
 
 
 
@@ -22,5 +23,6 @@ app.include_router(games_router)
 app.include_router(players_router)
 app.include_router(records_router)
 app.include_router(achievements_router)
+app.include_router(elo_router)
 
 

--- a/backend/mappers/elo_mapper.py
+++ b/backend/mappers/elo_mapper.py
@@ -1,5 +1,6 @@
+from db.models import PlayerEloHistory as PlayerEloHistoryORM
 from models.elo_change import EloChange
-from schemas.elo import EloChangeDTO
+from schemas.elo import EloChangeDTO, EloHistoryPointDTO, PlayerEloHistoryDTO
 
 
 def elo_change_to_dto(change: EloChange, player_name: str) -> EloChangeDTO:
@@ -20,3 +21,30 @@ def elo_changes_to_dtos(
         elo_change_to_dto(c, players_by_id.get(c.player_id, c.player_id))
         for c in changes
     ]
+
+
+def elo_history_changes_to_player_dto(
+    player_id: str,
+    player_name: str,
+    history_rows: list[PlayerEloHistoryORM],
+) -> PlayerEloHistoryDTO:
+    """
+    Convierte filas ya agrupadas y ya ordenadas (por recorded_at, game_id) en
+    PlayerEloHistoryDTO. El mapper NO ordena, NO consulta la BD, NO filtra:
+    es una transformación pura. El service garantiza el orden vía el order_by
+    del repository (player_id, recorded_at, game_id).
+    """
+    points = [
+        EloHistoryPointDTO(
+            recorded_at=r.recorded_at,
+            game_id=r.game_id,
+            elo_after=r.elo_after,
+            delta=r.delta,
+        )
+        for r in history_rows
+    ]
+    return PlayerEloHistoryDTO(
+        player_id=player_id,
+        player_name=player_name,
+        points=points,
+    )

--- a/backend/repositories/elo_filters.py
+++ b/backend/repositories/elo_filters.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class EloHistoryFilter:
+    date_from: Optional[date] = None
+    player_ids: Optional[set[str]] = None

--- a/backend/repositories/elo_repository.py
+++ b/backend/repositories/elo_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy import func
 
 from db.session import get_session
 from db.models import PlayerEloHistory as PlayerEloHistoryORM
+from repositories.elo_filters import EloHistoryFilter
 from models.elo_change import EloChange
 
 
@@ -125,3 +126,22 @@ class EloRepository:
                 elo_after=orm.elo_after,
                 delta=orm.delta,
             )
+
+    def get_history(self, filter: EloHistoryFilter) -> list[PlayerEloHistoryORM]:
+        """
+        Devuelve filas de PlayerEloHistory ordenadas por (player_id, recorded_at, game_id),
+        opcionalmente filtradas por fecha desde y/o conjunto de player_ids.
+        UNA sola query indexada (recorded_at y player_id son index=True).
+        """
+        with self._session_factory() as session:
+            query = session.query(PlayerEloHistoryORM)
+            if filter.date_from is not None:
+                query = query.filter(PlayerEloHistoryORM.recorded_at >= filter.date_from)
+            if filter.player_ids is not None:
+                query = query.filter(PlayerEloHistoryORM.player_id.in_(filter.player_ids))
+            rows = query.order_by(
+                PlayerEloHistoryORM.player_id,
+                PlayerEloHistoryORM.recorded_at,
+                PlayerEloHistoryORM.game_id,
+            ).all()
+            return list(rows)

--- a/backend/routes/elo_routes.py
+++ b/backend/routes/elo_routes.py
@@ -1,0 +1,21 @@
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from schemas.elo import PlayerEloHistoryDTO
+from services.container import elo_service
+
+
+router = APIRouter(prefix="/elo", tags=["Elo"])
+
+
+@router.get("/history", response_model=list[PlayerEloHistoryDTO])
+def get_elo_history(
+    from_: Optional[date] = Query(None, alias="from"),
+    player_ids: Optional[str] = Query(None),
+):
+    ids_set: Optional[set[str]] = (
+        {p for p in player_ids.split(",") if p} if player_ids else None
+    )
+    return elo_service.get_history(date_from=from_, player_ids=ids_set)

--- a/backend/schemas/elo.py
+++ b/backend/schemas/elo.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from pydantic import BaseModel
 
 
@@ -7,3 +9,16 @@ class EloChangeDTO(BaseModel):
     elo_before: int
     elo_after: int
     delta: int
+
+
+class EloHistoryPointDTO(BaseModel):
+    recorded_at: date
+    game_id: str
+    elo_after: int
+    delta: int
+
+
+class PlayerEloHistoryDTO(BaseModel):
+    player_id: str
+    player_name: str
+    points: list[EloHistoryPointDTO]

--- a/backend/services/elo_service.py
+++ b/backend/services/elo_service.py
@@ -1,7 +1,11 @@
 from datetime import date
+from typing import Optional
 
+from mappers.elo_mapper import elo_history_changes_to_player_dto
 from models.elo_change import EloChange
 from models.game import Game
+from repositories.elo_filters import EloHistoryFilter
+from schemas.elo import PlayerEloHistoryDTO
 from schemas.elo_summary import EloRankDTO, PlayerEloSummaryDTO
 from services.helpers.results import calculate_results
 
@@ -147,3 +151,57 @@ class EloService:
             if p.player_id == player_id:
                 return EloRankDTO(position=idx + 1, total=len(ranked))
         return None
+
+    def get_history(
+        self,
+        date_from: Optional[date] = None,
+        player_ids: Optional[set[str]] = None,
+    ) -> list[PlayerEloHistoryDTO]:
+        """
+        Devuelve la serie temporal de ELO por jugador.
+
+        - Sin player_ids: candidatos = jugadores activos (is_active == True).
+        - Con player_ids: candidatos = ids explícitos (activos o no);
+          ids desconocidos se descartan silenciosamente.
+        - Jugadores sin historial en la ventana se omiten del resultado.
+        - Orden top-level: ascendente por player_name (determinístico para tests).
+        """
+        candidate_ids, names_by_id = self._resolve_candidates(player_ids)
+        if not candidate_ids:
+            return []
+
+        rows = self.elo_repository.get_history(
+            EloHistoryFilter(date_from=date_from, player_ids=candidate_ids)
+        )
+
+        rows_by_player: dict[str, list] = {}
+        for r in rows:
+            rows_by_player.setdefault(r.player_id, []).append(r)
+
+        return [
+            elo_history_changes_to_player_dto(
+                player_id=pid,
+                player_name=names_by_id[pid],
+                history_rows=rows_by_player[pid],
+            )
+            for pid in sorted(rows_by_player.keys(), key=lambda p: names_by_id[p])
+        ]
+
+    def _resolve_candidates(
+        self,
+        player_ids: Optional[set[str]],
+    ) -> tuple[set[str], dict[str, str]]:
+        """
+        Resuelve el conjunto de candidatos y el mapa player_id->name en una sola pasada
+        sobre players_repository.get_all().
+
+        - player_ids None  -> activos (is_active == True).
+        - player_ids set   -> intersección con players existentes (unknown ids dropped).
+        """
+        all_players = self.players_repository.get_all()
+        names_by_id = {p.player_id: p.name for p in all_players}
+        if player_ids is None:
+            candidate_ids = {p.player_id for p in all_players if p.is_active}
+        else:
+            candidate_ids = {pid for pid in player_ids if pid in names_by_id}
+        return candidate_ids, names_by_id

--- a/backend/tests/integration/_elo_helpers.py
+++ b/backend/tests/integration/_elo_helpers.py
@@ -1,0 +1,55 @@
+"""
+Shared helpers for ELO integration tests.
+
+Extracted from test_elo_cascade.py per CLAUDE.md §3 (no code duplication).
+Used by test_elo_routes.py (Phase 8). The original copies in test_elo_cascade.py
+remain in place — consolidating that file is OUT OF SCOPE for Phase 8.
+
+The leading underscore marks this module as test-internal. Pytest does NOT
+collect modules whose name starts with `_`, so this file is not a test file.
+"""
+
+
+def _player_result(player_id: str, terraform_rating: int, corp: str = "Credicor") -> dict:
+    return {
+        "player_id": player_id,
+        "corporation": corp,
+        "scores": {
+            "terraform_rating": terraform_rating,
+            "milestone_points": 0,
+            "milestones": [],
+            "award_points": 0,
+            "card_points": 0,
+            "card_resource_points": 0,
+            "greenery_points": 0,
+            "city_points": 0,
+            "turmoil_points": None,
+        },
+        "end_stats": {"mc_total": 0},
+    }
+
+
+_CORP_BY_PLAYER = {"p1": "Credicor", "p2": "Ecoline", "p3": "Helion"}
+
+
+def _pr(player_id: str, terraform_rating: int) -> dict:
+    return _player_result(player_id, terraform_rating, _CORP_BY_PLAYER[player_id])
+
+
+def _game_payload(game_id: str, on_date: str, results: list[dict]) -> dict:
+    return {
+        "id": game_id,
+        "date": on_date,
+        "map": "Hellas",
+        "expansions": [],
+        "draft": False,
+        "generations": 10,
+        "player_results": results,
+        "awards": [],
+    }
+
+
+def _post_game(client, payload: dict) -> str:
+    res = client.post("/games/", json=payload)
+    assert res.status_code == 200, res.json()
+    return res.json()["id"]

--- a/backend/tests/integration/test_elo_routes.py
+++ b/backend/tests/integration/test_elo_routes.py
@@ -1,0 +1,196 @@
+"""
+Integration tests for GET /elo/history.
+
+Covers the four ROADMAP success criteria for ELO-API-01:
+1. No filters → one entry per active player with non-empty points
+2. ?from=YYYY-MM-DD → recorded_at >= from, no off-by-one drift in non-UTC TZ
+3. ?player_ids=valid,unknown → only valid is returned (200, not 400)
+4. Invalid ?from value → 422
+
+All tests run inside docker-compose.test.yml via `make test-backend`
+(NEVER pytest on host — wipes dev DB). The Makefile recipe runs the FULL
+suite; there is no per-file selection from the host.
+
+Helpers are imported from _elo_helpers.py (CLAUDE.md §3 — no duplication
+of code introduced by Phase 8). The integration directory has no
+__init__.py, so the import is absolute (pytest's rootdir-based collection
+adds the test file's directory to sys.path).
+"""
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from models.player import Player
+from repositories.player_repository import PlayersRepository
+
+from _elo_helpers import (
+    _CORP_BY_PLAYER,  # noqa: F401  (re-exported for completeness; safe to drop if unused)
+    _game_payload,
+    _player_result,  # noqa: F401  (re-exported for completeness; safe to drop if unused)
+    _post_game,
+    _pr,
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def players_repo():
+    return PlayersRepository()
+
+
+# ---------- Test-local helpers (specific to this file's fixtures) ----------
+
+def _seed_three_active_players(players_repo) -> list[str]:
+    players_repo.create(Player(player_id="p1", name="Alice"))
+    players_repo.create(Player(player_id="p2", name="Bob"))
+    players_repo.create(Player(player_id="p3", name="Cara"))
+    return ["p1", "p2", "p3"]
+
+
+def _seed_two_games(client) -> tuple[str, str]:
+    g1 = _post_game(client, _game_payload(
+        "g-jan", "2026-01-15",
+        [_pr("p1", 50), _pr("p2", 30), _pr("p3", 20)],
+    ))
+    g2 = _post_game(client, _game_payload(
+        "g-feb", "2026-02-15",
+        [_pr("p2", 50), _pr("p3", 30), _pr("p1", 20)],
+    ))
+    return g1, g2
+
+
+# ---------- Success Criterion 1 ----------
+
+def test_history_no_filters_returns_active_players_with_points(client, players_repo):
+    _seed_three_active_players(players_repo)
+    _seed_two_games(client)
+
+    res = client.get("/elo/history")
+    assert res.status_code == 200, res.json()
+    data = res.json()
+
+    # All three active players appear (each played both games)
+    ids = {entry["player_id"] for entry in data}
+    assert ids == {"p1", "p2", "p3"}, f"unexpected ids: {ids}"
+
+    # Each player has 2 points covering both games
+    for entry in data:
+        assert len(entry["points"]) == 2, entry
+        game_ids = {p["game_id"] for p in entry["points"]}
+        assert game_ids == {"g-jan", "g-feb"}, entry
+
+    # Names are resolved (not just ids)
+    names = {entry["player_id"]: entry["player_name"] for entry in data}
+    assert names == {"p1": "Alice", "p2": "Bob", "p3": "Cara"}
+
+
+# ---------- Success Criterion 2 ----------
+
+def test_history_from_filter_drops_earlier_points_in_non_utc_tz(monkeypatch, client, players_repo):
+    """
+    Defensive regression test for the ?from filter under a non-UTC runtime TZ.
+
+    Important context: PITFALLS.md §4 (timezone shift) actually applies to the
+    FRONTEND `new Date("YYYY-MM-DD").toISOString()` chain that Phase 11 will
+    introduce — NOT to this backend. The backend stores `recorded_at` as a
+    Postgres `Date` column (TZ-naive) and serializes it via Pydantic's default
+    `date` serializer (TZ-naive YYYY-MM-DD). The runtime TZ env var has no
+    path to influence either, so this test cannot reproduce the actual
+    pitfall against the current codebase.
+
+    Why keep the test then?
+    - It is a CHEAP regression guard: if a future change introduces a
+      `datetime` (TZ-aware) anywhere in the read chain — for example, by
+      coercing `recorded_at` into a `datetime` in the DTO or by deriving it
+      from `created_at: TIMESTAMPTZ` — this test would fail when the runtime
+      TZ shifts the day boundary.
+    - CONTEXT 08 explicitly requires "one test runs in
+      America/Argentina/Buenos_Aires TZ" to satisfy ROADMAP success
+      criterion 2. We satisfy that requirement with a defensive, not a
+      reproductive, test.
+    - The test still exercises the inclusive lower bound (`from=2026-02-15`
+      keeps the Feb game, drops the Jan game) — which is the OTHER half of
+      success criterion 2 and IS reproducible against the current backend.
+
+    If the test ever starts failing after a future change, do NOT silence it:
+    the failure mode is exactly what it exists to catch.
+    """
+    # monkeypatch.setenv runs after top-level imports, so this only affects
+    # processes spawned (or libraries that re-read TZ) AFTER this point.
+    monkeypatch.setenv("TZ", "America/Argentina/Buenos_Aires")
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    _seed_three_active_players(players_repo)
+    _seed_two_games(client)  # games on 2026-01-15 and 2026-02-15
+
+    # Inclusive lower bound: from=2026-02-15 keeps the Feb game, drops the Jan game.
+    res = client.get("/elo/history?from=2026-02-15")
+    assert res.status_code == 200, res.json()
+    data = res.json()
+    assert data, "expected non-empty response under from=2026-02-15"
+
+    for entry in data:
+        for point in entry["points"]:
+            # Compare YYYY-MM-DD as opaque strings (no parsing). If a future
+            # change reformats `recorded_at` into a TZ-aware ISO datetime,
+            # this string compare will catch the drift.
+            assert point["recorded_at"] >= "2026-02-15", point
+            assert point["game_id"] == "g-feb", point
+
+
+# ---------- Success Criterion 3 ----------
+
+def test_history_player_ids_filter_drops_unknown_ids_silently(client, players_repo):
+    _seed_three_active_players(players_repo)
+    _seed_two_games(client)
+
+    res = client.get("/elo/history?player_ids=p1,does-not-exist")
+    # Unknown ids must NOT trigger 400/422 — they are silently dropped (CONTEXT D-03).
+    assert res.status_code == 200, res.json()
+    data = res.json()
+
+    ids = {entry["player_id"] for entry in data}
+    assert ids == {"p1"}, f"expected only p1, got {ids}"
+
+
+# ---------- Success Criterion 4 ----------
+
+def test_history_invalid_from_returns_422(client, players_repo):
+    _seed_three_active_players(players_repo)
+    # No games needed — invalid query param is rejected before any service work.
+
+    res = client.get("/elo/history?from=not-a-date")
+    assert res.status_code == 422, res.json()
+
+
+def test_history_response_shape_matches_player_elo_history_dto(client, players_repo):
+    _seed_three_active_players(players_repo)
+    _seed_two_games(client)
+
+    res = client.get("/elo/history?player_ids=p1")
+    assert res.status_code == 200, res.json()
+    data = res.json()
+
+    assert len(data) == 1
+    entry = data[0]
+
+    # Top-level fields locked by PlayerEloHistoryDTO
+    assert set(entry.keys()) == {"player_id", "player_name", "points"}, entry.keys()
+
+    # Each point matches EloHistoryPointDTO field-for-field
+    assert entry["points"], "expected non-empty points"
+    for point in entry["points"]:
+        assert set(point.keys()) == {"recorded_at", "game_id", "elo_after", "delta"}, point.keys()
+        # recorded_at serialized as YYYY-MM-DD string (Pydantic default for date)
+        assert isinstance(point["recorded_at"], str)
+        assert len(point["recorded_at"]) == 10 and point["recorded_at"][4] == "-" and point["recorded_at"][7] == "-", point["recorded_at"]
+        assert isinstance(point["game_id"], str)
+        assert isinstance(point["elo_after"], int)
+        assert isinstance(point["delta"], int)


### PR DESCRIPTION
## Summary

- Adds `GET /elo/history` endpoint exposing per-player ELO time series — gates Phase 11 (Ranking page) and Phase 12 (Ranking chart) which both consume this contract.
- Full vertical: DTOs (`PlayerEloHistoryDTO`, `EloHistoryPointDTO`) → `EloHistoryFilter` dataclass → `EloRepository.get_history(filter)` → `EloService.get_history(date_from, player_ids)` → `GET /elo/history` route → registered in `main.py`.
- 5 new integration tests cover the 4 ROADMAP success criteria + a defensive TZ regression. Backend suite went 187 → 192 passed (zero regressions verified locally via `make test-backend`).
- Code review: 1 medium (TZ test pollution — `time.tzset()` not restored), 2 low, 4 info. Non-blocking; tracked in `08-REVIEW.md`.

## Context — why this PR is appearing now

Phase 8 was completed end-to-end on `phase/08-elo-history-backend` but never PR'd. Phase 9 (PlayerProfile ELO + foundation) was developed and merged to `staging` independently in the meantime. This branch was rebased onto current `staging` to pick up Phase 9; conflicts were limited to:

- `backend/services/elo_service.py` — both phases append-only added new methods to `EloService`. Resolved by keeping both (`get_summary_for_player` from Phase 9 + `get_history` from Phase 8).
- `backend/repositories/elo_repository.py` — same append-only pattern. Resolved by keeping both (`get_peak_for_player` / `get_last_change_for_player` from Phase 9 + `get_history` from Phase 8).
- `.planning/STATE.md` and `.planning/ROADMAP.md` — tracking files. Took staging's version + final commit to mark Phase 8 ✓.

## What's in this PR

- 9 backend code files: `main.py`, `mappers/elo_mapper.py`, `repositories/elo_filters.py`, `repositories/elo_repository.py`, `routes/elo_routes.py`, `schemas/elo.py`, `services/elo_service.py`, `tests/integration/_elo_helpers.py`, `tests/integration/test_elo_routes.py`
- Planning artifacts under `.planning/phases/08-backend-get-elo-history-endpoint/` (CONTEXT, RESEARCH, DISCUSSION-LOG, 4 PLANs, 4 SUMMARYs, REVIEW, VERIFICATION)
- `.planning/REQUIREMENTS.md`: ELO-API-01 marked complete
- `.planning/ROADMAP.md`: Phase 8 row marked Complete (4/4)
- `.planning/PROJECT.md`: ELO-API-01 in Validated section

Net diff: **+2404 / -6** across 21 files. No Phase 9 deletions.

## Test plan

- [x] `make test-backend` passes locally (192 passed, 1.84s)
- [x] CI green on this PR
- [ ] Manual smoke test of the live endpoint after merge:
  ```bash
  curl -sS http://localhost:8000/elo/history | python3 -m json.tool | head -30
  ```
  Verify response shape matches `PlayerEloHistoryDTO[]` field-for-field (`player_id`, `player_name`, `points[*].recorded_at|game_id|elo_after|delta`).

## Why merge now

Phase 11 (`/ranking` page) is in progress on branch `phase-11-ranking-context`. Plan 11-02 needs `getEloHistory()` to call this endpoint. Without this PR merged, Phase 11 cannot continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)