### PR TITLE
feat: agregar opciones Venus Next (HOVERLORD/VENUPHILE) a selects de creación de partida

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-03-21)
 Phase: 14
 Plan: Not started
 Status: Executing Phase 14
-Last activity: 2026-05-03
+Last activity: 2026-05-03 - Completed quick task 260502-vc2: agregar opciones Venus Next a selects de hitos y recompensas en creacion de partida
 
 Progress: [          ] 0%
 
@@ -111,6 +111,7 @@ None yet.
 | # | Description | Date | Commit | Directory |
 |---|-------------|------|--------|-----------|
 | 260501-r3p | Fix enums de Awards Tharsis en backend + DB, y agregar Hito y Recompensa de expansión Venus | 2026-05-01 | c0f365a | [260501-r3p-fix-enums-de-awards-tharsis-en-backend-d](./quick/260501-r3p-fix-enums-de-awards-tharsis-en-backend-d/) |
+| 260502-vc2 | agregar opciones Venus Next a selects de hitos y recompensas en creacion de partida | 2026-05-03 | 2f66ae2 | [260502-vc2-agregar-opciones-venus-next-a-selects-de](./quick/260502-vc2-agregar-opciones-venus-next-a-selects-de/) |
 
 ### Blockers/Concerns
 

--- a/.planning/quick/260502-vc2-agregar-opciones-venus-next-a-selects-de/260502-vc2-PLAN.md
+++ b/.planning/quick/260502-vc2-agregar-opciones-venus-next-a-selects-de/260502-vc2-PLAN.md
@@ -1,0 +1,245 @@
+---
+quick_task: 260502-vc2
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - frontend/src/constants/gameRules.ts
+  - frontend/src/pages/GameForm/steps/StepMilestones.tsx
+  - frontend/src/pages/GameForm/steps/StepAwards.tsx
+  - frontend/src/test/unit/gameRules.test.ts
+  - frontend/src/test/components/StepMilestones.test.tsx
+  - frontend/src/test/components/StepAwards.test.tsx
+autonomous: true
+requirements:
+  - VN-01
+  - VN-02
+  - VN-03
+  - VN-04
+  - VN-05
+
+must_haves:
+  truths:
+    - "HOVERLORD aparece en el listado de hitos cuando Venus Next está activo en expansions"
+    - "HOVERLORD no aparece cuando Venus Next no está en expansions"
+    - "VENUPHILE aparece en las opciones de recompensa cuando Venus Next está activo"
+    - "VENUPHILE no aparece cuando Venus Next no está en expansions"
+    - "El cap de 3 hitos y 3 recompensas no cambia"
+  artifacts:
+    - path: "frontend/src/constants/gameRules.ts"
+      provides: "EXPANSION_MILESTONES y EXPANSION_AWARDS lookup tables"
+      contains: "EXPANSION_MILESTONES"
+    - path: "frontend/src/pages/GameForm/steps/StepMilestones.tsx"
+      provides: "Merge de milestones de mapa + expansión"
+    - path: "frontend/src/pages/GameForm/steps/StepAwards.tsx"
+      provides: "Merge de awards de mapa + expansión"
+  key_links:
+    - from: "StepMilestones.tsx"
+      to: "gameRules.ts EXPANSION_MILESTONES"
+      via: "import + flatMap sobre state.expansions"
+    - from: "StepAwards.tsx"
+      to: "gameRules.ts EXPANSION_AWARDS"
+      via: "import + flatMap sobre state.expansions"
+---
+
+<objective>
+Surfacear HOVERLORD (hito) y VENUPHILE (recompensa) en el formulario de creación de partida cuando la expansión Venus Next está seleccionada.
+
+Purpose: Los enum values ya existen en frontend y backend, y el backend ya valida que solo se permitan si Venus Next está en expansiones. Solo falta que el frontend los muestre en las listas de opciones.
+Output: gameRules.ts con dos nuevas tablas de lookup; StepMilestones y StepAwards actualizados para mergear opciones de mapa + expansión; tests cubriendo el comportamiento condicional.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/phases/13-agregarle-al-front-end-la-posibilidad-de-seleccionar-el-hito/13-RESEARCH.md
+
+<interfaces>
+<!-- Contratos clave para el ejecutor. Extraídos del codebase. -->
+
+De frontend/src/constants/enums.ts:
+```typescript
+export enum Expansion {
+  PRELUDE = 'Prelude',
+  COLONIES = 'Colonies',
+  TURMOIL = 'Turmoil',
+  VENUS_NEXT = 'Venus next',
+}
+
+export enum Milestone {
+  // ...
+  HOVERLORD = 'Hoverlord',   // Venus Next
+}
+
+export enum Award {
+  // ...
+  VENUPHILE = 'Venuphile',   // Venus Next
+}
+```
+
+De frontend/src/pages/GameForm/GameForm.types.ts:
+```typescript
+export interface GameFormState {
+  expansions: Expansion[]   // ya incluido en el estado del formulario
+  map: MapName | ''
+  milestones: MilestoneEntry[]
+  awards: AwardEntry[]
+  // ...
+}
+```
+
+De frontend/src/constants/gameRules.ts (estado actual — sin Venus):
+```typescript
+export const MAP_MILESTONES: Record<MapName, Milestone[]> = { /* 5 entradas de mapa */ }
+export const MAP_AWARDS: Record<MapName, Award[]> = { /* 5 entradas de mapa */ }
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Agregar EXPANSION_MILESTONES y EXPANSION_AWARDS a gameRules.ts</name>
+  <files>
+    frontend/src/constants/gameRules.ts
+    frontend/src/test/unit/gameRules.test.ts
+  </files>
+  <behavior>
+    - EXPANSION_MILESTONES[Expansion.VENUS_NEXT] === [Milestone.HOVERLORD]
+    - EXPANSION_AWARDS[Expansion.VENUS_NEXT] === [Award.VENUPHILE]
+    - Las tablas MAP_MILESTONES y MAP_AWARDS existentes no deben modificarse (no agregar Venus a ningún mapa)
+    - Los tests existentes de gameRules (5 milestones por mapa, 5 awards por mapa) deben seguir pasando sin cambios
+  </behavior>
+  <action>
+    En gameRules.ts, después de las tablas MAP_MILESTONES y MAP_AWARDS, agregar:
+
+    ```typescript
+    import { Expansion, MapName, Milestone, Award } from './enums'
+
+    export const EXPANSION_MILESTONES: Partial<Record<Expansion, Milestone[]>> = {
+      [Expansion.VENUS_NEXT]: [Milestone.HOVERLORD],
+    }
+
+    export const EXPANSION_AWARDS: Partial<Record<Expansion, Award[]>> = {
+      [Expansion.VENUS_NEXT]: [Award.VENUPHILE],
+    }
+    ```
+
+    En gameRules.test.ts, agregar un nuevo describe block con los tests de las tablas de expansión:
+    - EXPANSION_MILESTONES[VENUS_NEXT] contiene HOVERLORD
+    - EXPANSION_AWARDS[VENUS_NEXT] contiene VENUPHILE
+    - Otras expansiones (PRELUDE, COLONIES, TURMOIL) no tienen entradas (undefined o array vacío)
+
+    NO modificar los tests existentes de MAP_MILESTONES / MAP_AWARDS.
+  </action>
+  <verify>
+    <automated>cd /Users/facu/Desarrollos/Personales/tm-scorekeeper/frontend && npx vitest run src/test/unit/gameRules.test.ts</automated>
+  </verify>
+  <done>gameRules.ts exporta EXPANSION_MILESTONES y EXPANSION_AWARDS; todos los tests de gameRules.test.ts pasan en verde.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Actualizar StepMilestones y StepAwards para mergeear opciones de expansión</name>
+  <files>
+    frontend/src/pages/GameForm/steps/StepMilestones.tsx
+    frontend/src/pages/GameForm/steps/StepAwards.tsx
+    frontend/src/test/components/StepMilestones.test.tsx
+    frontend/src/test/components/StepAwards.test.tsx
+  </files>
+  <behavior>
+    StepMilestones:
+    - Con Venus Next activo y cualquier mapa: HOVERLORD aparece como opción (checkbox visible)
+    - Sin Venus Next en expansions: HOVERLORD NO aparece
+    - Con Venus Next activo pero sin mapa seleccionado: HOVERLORD SÍ aparece (las opciones de expansión son independientes del mapa)
+    - Los 5 hitos del mapa siguen apareciendo sin cambios
+
+    StepAwards:
+    - Con Venus Next activo: VENUPHILE aparece en el select de recompensas
+    - Sin Venus Next: VENUPHILE NO aparece en el select
+    - Los awards del mapa actual siguen apareciendo sin cambios
+  </behavior>
+  <action>
+    En StepMilestones.tsx:
+    - Importar EXPANSION_MILESTONES desde '@/constants/gameRules'
+    - Reemplazar la línea de availableMilestones:
+      ```typescript
+      const mapMilestones: Milestone[] = state.map ? MAP_MILESTONES[state.map as MapName] ?? [] : []
+      const expansionMilestones: Milestone[] = state.expansions.flatMap(
+        (exp) => EXPANSION_MILESTONES[exp] ?? []
+      )
+      const availableMilestones: Milestone[] = [...mapMilestones, ...expansionMilestones]
+      ```
+
+    En StepAwards.tsx:
+    - Importar EXPANSION_AWARDS desde '@/constants/gameRules'
+    - Reemplazar la línea de availableAwards:
+      ```typescript
+      const mapAwards: Award[] = state.map ? MAP_AWARDS[state.map as MapName] ?? [] : []
+      const expansionAwards: Award[] = state.expansions.flatMap(
+        (exp) => EXPANSION_AWARDS[exp] ?? []
+      )
+      const availableAwards: Award[] = [...mapAwards, ...expansionAwards]
+      ```
+
+    En StepMilestones.test.tsx, agregar tests:
+    - "muestra HOVERLORD cuando Venus Next está en expansions" — usar stateWithTharsis con expansions: [Expansion.VENUS_NEXT], verificar que hay 6 checkboxes (5 Tharsis + Hoverlord)
+    - "no muestra HOVERLORD cuando Venus Next no está en expansions" — usar stateWithTharsis sin expansión Venus, verificar 5 checkboxes
+
+    En StepAwards.test.tsx, agregar tests:
+    - "incluye VENUPHILE en opciones de recompensa cuando Venus Next está activo" — agregar un award, abrir el select, verificar que VENUPHILE aparece como opción
+    - "no incluye VENUPHILE cuando Venus Next no está activo" — sin expansión Venus, verificar que VENUPHILE no aparece en las opciones
+
+    IMPORTANTE: No modificar los tests existentes de estos archivos.
+  </action>
+  <verify>
+    <automated>cd /Users/facu/Desarrollos/Personales/tm-scorekeeper/frontend && npx vitest run src/test/components/StepMilestones.test.tsx src/test/components/StepAwards.test.tsx</automated>
+  </verify>
+  <done>
+    StepMilestones muestra HOVERLORD cuando y solo cuando Venus Next está en expansions.
+    StepAwards incluye VENUPHILE cuando y solo cuando Venus Next está en expansions.
+    Suite completa de tests en verde: cd frontend && npx vitest run
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Frontend form → Backend API | Los valores HOVERLORD / VENUPHILE enviados en el payload deben pasar la validación backend |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-vc2-01 | Tampering | POST /games payload | accept | Backend ya tiene `_validate_venus_requirements` que rechaza HOVERLORD/VENUPHILE si VENUS_NEXT no está en expansions. Frontend es una capa de UX, no de seguridad. |
+</threat_model>
+
+<verification>
+Suite completa del frontend en verde:
+
+```bash
+cd /Users/facu/Desarrollos/Personales/tm-scorekeeper/frontend && npx vitest run
+```
+
+Verificación manual: En el formulario de creación de partida, seleccionar la expansión Venus Next → HOVERLORD debe aparecer en el paso de hitos y VENUPHILE debe aparecer en el desplegable de recompensas. Deseleccionar Venus Next → desaparecen.
+</verification>
+
+<success_criteria>
+- EXPANSION_MILESTONES y EXPANSION_AWARDS exportados desde gameRules.ts
+- StepMilestones muestra HOVERLORD si y solo si Venus Next está en expansions
+- StepAwards incluye VENUPHILE si y solo si Venus Next está en expansions
+- Todos los tests nuevos y existentes pasan (npx vitest run)
+- No se modifican MAP_MILESTONES ni MAP_AWARDS (solo agregar las tablas EXPANSION_*)
+- Los caps MAX_MILESTONES=3 y MAX_AWARDS=3 no cambian
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260502-vc2-agregar-opciones-venus-next-a-selects-de/260502-vc2-SUMMARY.md`
+</output>

--- a/.planning/quick/260502-vc2-agregar-opciones-venus-next-a-selects-de/260502-vc2-SUMMARY.md
+++ b/.planning/quick/260502-vc2-agregar-opciones-venus-next-a-selects-de/260502-vc2-SUMMARY.md
@@ -1,0 +1,78 @@
+---
+quick_task: 260502-vc2
+status: complete
+completed_date: "2026-05-02"
+duration_minutes: 5
+tasks_completed: 2
+tasks_total: 2
+files_changed: 6
+commits:
+  - hash: 9bfff8c
+    message: "feat(vc2): add EXPANSION_MILESTONES and EXPANSION_AWARDS to gameRules.ts"
+  - hash: 2f66ae2
+    message: "feat(vc2): show HOVERLORD and VENUPHILE when Venus Next expansion is active"
+requirements_fulfilled:
+  - VN-01
+  - VN-02
+  - VN-03
+  - VN-04
+  - VN-05
+key_files:
+  modified:
+    - frontend/src/constants/gameRules.ts
+    - frontend/src/pages/GameForm/steps/StepMilestones.tsx
+    - frontend/src/pages/GameForm/steps/StepAwards.tsx
+    - frontend/src/test/unit/gameRules.test.ts
+    - frontend/src/test/components/StepMilestones.test.tsx
+    - frontend/src/test/components/StepAwards.test.tsx
+---
+
+# Quick Task 260502-vc2 Summary
+
+**One-liner:** Venus Next expansion HOVERLORD milestone and VENUPHILE award now appear conditionally in GameForm steps via EXPANSION_MILESTONES / EXPANSION_AWARDS lookup tables.
+
+## What Was Built
+
+Two lookup tables were added to `gameRules.ts` mapping expansions to their additional milestones and awards. The `StepMilestones` and `StepAwards` components were updated to merge map-specific options with expansion-specific options via `flatMap`.
+
+## Tasks
+
+### Task 1: Add EXPANSION_MILESTONES and EXPANSION_AWARDS to gameRules.ts (commit 9bfff8c)
+
+- Added `Expansion` to the imports in `gameRules.ts`
+- Exported `EXPANSION_MILESTONES: Partial<Record<Expansion, Milestone[]>>` with `VENUS_NEXT → [HOVERLORD]`
+- Exported `EXPANSION_AWARDS: Partial<Record<Expansion, Award[]>>` with `VENUS_NEXT → [VENUPHILE]`
+- Added tests: Venus Next contains HOVERLORD/VENUPHILE; PRELUDE/COLONIES/TURMOIL are undefined
+
+### Task 2: Merge expansion options in StepMilestones and StepAwards (commit 2f66ae2)
+
+- `StepMilestones`: split into `mapMilestones` + `expansionMilestones` (via `flatMap` over `state.expansions`), merged into `availableMilestones`
+- `StepAwards`: split into `mapAwards` + `expansionAwards` (via `flatMap` over `state.expansions`), merged into `availableAwards`
+- Tests: HOVERLORD visible with Venus Next active (6 checkboxes), hidden without (5 checkboxes)
+- Tests: VENUPHILE visible in award select with Venus Next active, hidden without
+
+## Test Results
+
+All 243 tests pass across 25 test files.
+
+```
+Test Files  25 passed (25)
+Tests       243 passed (243)
+```
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Threat Surface Scan
+
+No new network endpoints, auth paths, or schema changes introduced. Frontend-only change; backend already validates HOVERLORD/VENUPHILE against Venus Next presence (T-vc2-01 in threat model).
+
+## Self-Check
+
+- [x] `frontend/src/constants/gameRules.ts` exports `EXPANSION_MILESTONES` and `EXPANSION_AWARDS`
+- [x] `StepMilestones.tsx` uses `flatMap` over `state.expansions`
+- [x] `StepAwards.tsx` uses `flatMap` over `state.expansions`
+- [x] Commit 9bfff8c exists
+- [x] Commit 2f66ae2 exists
+- [x] Full suite: 243/243 tests passing

--- a/frontend/src/constants/gameRules.ts
+++ b/frontend/src/constants/gameRules.ts
@@ -1,4 +1,4 @@
-import { MapName, Milestone, Award } from './enums'
+import { Expansion, MapName, Milestone, Award } from './enums'
 
 export const MAX_MILESTONES = 3
 export const MAX_AWARDS = 3
@@ -82,4 +82,12 @@ export const MAP_AWARDS: Record<MapName, Award[]> = {
     Award.MANUFACTURER,
     Award.PHYSICIST,
   ],
+}
+
+export const EXPANSION_MILESTONES: Partial<Record<Expansion, Milestone[]>> = {
+  [Expansion.VENUS_NEXT]: [Milestone.HOVERLORD],
+}
+
+export const EXPANSION_AWARDS: Partial<Record<Expansion, Award[]>> = {
+  [Expansion.VENUS_NEXT]: [Award.VENUPHILE],
 }

--- a/frontend/src/pages/GameForm/steps/StepAwards.tsx
+++ b/frontend/src/pages/GameForm/steps/StepAwards.tsx
@@ -1,7 +1,7 @@
 import Select from '@/components/Select/Select'
 import MultiSelect from '@/components/MultiSelect/MultiSelect'
 import Button from '@/components/Button/Button'
-import { MAP_AWARDS, MAX_AWARDS } from '@/constants/gameRules'
+import { EXPANSION_AWARDS, MAP_AWARDS, MAX_AWARDS } from '@/constants/gameRules'
 import { Award, MapName } from '@/constants/enums'
 import type { GameFormState, AwardEntry } from '../GameForm.types'
 import styles from '../GameForm.module.css'
@@ -14,7 +14,11 @@ interface Props {
 const EMPTY_AWARD: AwardEntry = { name: '', opened_by: '', first_place: [], second_place: [] }
 
 export default function StepAwards({ state, onChange }: Props) {
-  const availableAwards: Award[] = state.map ? MAP_AWARDS[state.map as MapName] ?? [] : []
+  const mapAwards: Award[] = state.map ? MAP_AWARDS[state.map as MapName] ?? [] : []
+  const expansionAwards: Award[] = state.expansions.flatMap(
+    (exp) => EXPANSION_AWARDS[exp] ?? []
+  )
+  const availableAwards: Award[] = [...mapAwards, ...expansionAwards]
   const playerOptions = state.players.map((p) => ({ value: p.player_id, label: p.name }))
   const twoPlayerGame = state.players.length === 2
 

--- a/frontend/src/pages/GameForm/steps/StepMilestones.tsx
+++ b/frontend/src/pages/GameForm/steps/StepMilestones.tsx
@@ -1,5 +1,5 @@
 import Select from '@/components/Select/Select'
-import { MAP_MILESTONES, MAX_MILESTONES } from '@/constants/gameRules'
+import { EXPANSION_MILESTONES, MAP_MILESTONES, MAX_MILESTONES } from '@/constants/gameRules'
 import { MapName, type Milestone } from '@/constants/enums'
 import type { GameFormState, MilestoneEntry } from '../GameForm.types'
 import styles from '../GameForm.module.css'
@@ -10,7 +10,11 @@ interface Props {
 }
 
 export default function StepMilestones({ state, onChange }: Props) {
-  const availableMilestones: Milestone[] = state.map ? MAP_MILESTONES[state.map as MapName] ?? [] : []
+  const mapMilestones: Milestone[] = state.map ? MAP_MILESTONES[state.map as MapName] ?? [] : []
+  const expansionMilestones: Milestone[] = state.expansions.flatMap(
+    (exp) => EXPANSION_MILESTONES[exp] ?? []
+  )
+  const availableMilestones: Milestone[] = [...mapMilestones, ...expansionMilestones]
   const playerOptions = [
     { value: '', label: 'Nadie' },
     ...state.players.map((p) => ({ value: p.player_id, label: p.name })),

--- a/frontend/src/test/components/StepAwards.test.tsx
+++ b/frontend/src/test/components/StepAwards.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import StepAwards from '@/pages/GameForm/steps/StepAwards'
 import { INITIAL_GAME_STATE, type PlayerFormData } from '@/pages/GameForm/GameForm.types'
-import { MapName, Award } from '@/constants/enums'
+import { Expansion, MapName, Award } from '@/constants/enums'
 import type { GameFormState } from '@/pages/GameForm/GameForm.types'
 
 const basePlayers: PlayerFormData[] = [
@@ -92,5 +92,24 @@ describe('StepAwards', () => {
     }
     render(<StepAwards state={withTiedFirst} onChange={() => {}} />)
     expect(screen.queryByText(/2do puesto/i)).not.toBeInTheDocument()
+  })
+
+  it('incluye VENUPHILE en opciones de recompensa cuando Venus Next está activo', () => {
+    const stateWithVenus: GameFormState = {
+      ...stateWithHellas,
+      expansions: [Expansion.VENUS_NEXT],
+      awards: [{ name: '', opened_by: '', first_place: [], second_place: [] }],
+    }
+    render(<StepAwards state={stateWithVenus} onChange={() => {}} />)
+    expect(screen.getByText(Award.VENUPHILE)).toBeInTheDocument()
+  })
+
+  it('no incluye VENUPHILE cuando Venus Next no está activo', () => {
+    const stateNoVenus: GameFormState = {
+      ...stateWithHellas,
+      awards: [{ name: '', opened_by: '', first_place: [], second_place: [] }],
+    }
+    render(<StepAwards state={stateNoVenus} onChange={() => {}} />)
+    expect(screen.queryByText(Award.VENUPHILE)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/components/StepMilestones.test.tsx
+++ b/frontend/src/test/components/StepMilestones.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import StepMilestones from '@/pages/GameForm/steps/StepMilestones'
 import { INITIAL_GAME_STATE, type PlayerFormData } from '@/pages/GameForm/GameForm.types'
-import { MapName, Milestone } from '@/constants/enums'
+import { Expansion, MapName, Milestone } from '@/constants/enums'
 import type { GameFormState } from '@/pages/GameForm/GameForm.types'
 
 const basePlayers: PlayerFormData[] = [
@@ -49,5 +49,23 @@ describe('StepMilestones', () => {
     const checkboxes = screen.getAllByRole('checkbox')
     expect(checkboxes[3]).toBeDisabled()
     expect(checkboxes[4]).toBeDisabled()
+  })
+
+  it('muestra HOVERLORD cuando Venus Next está en expansions', () => {
+    const stateWithVenus: GameFormState = {
+      ...stateWithTharsis,
+      expansions: [Expansion.VENUS_NEXT],
+    }
+    render(<StepMilestones state={stateWithVenus} onChange={() => {}} />)
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(6)
+    expect(screen.getByText(Milestone.HOVERLORD)).toBeInTheDocument()
+  })
+
+  it('no muestra HOVERLORD cuando Venus Next no está en expansions', () => {
+    render(<StepMilestones state={stateWithTharsis} onChange={() => {}} />)
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(5)
+    expect(screen.queryByText(Milestone.HOVERLORD)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/unit/gameRules.test.ts
+++ b/frontend/src/test/unit/gameRules.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { MAP_MILESTONES, MAP_AWARDS, MAX_MILESTONES, MAX_AWARDS, MIN_PLAYERS, MAX_PLAYERS } from '@/constants/gameRules'
-import { MapName } from '@/constants/enums'
+import { MAP_MILESTONES, MAP_AWARDS, EXPANSION_MILESTONES, EXPANSION_AWARDS, MAX_MILESTONES, MAX_AWARDS, MIN_PLAYERS, MAX_PLAYERS } from '@/constants/gameRules'
+import { Expansion, MapName, Milestone, Award } from '@/constants/enums'
 
 const ALL_MAPS = Object.values(MapName)
 
@@ -52,5 +52,29 @@ describe('game constants', () => {
     expect(MAX_AWARDS).toBe(3)
     expect(MIN_PLAYERS).toBe(2)
     expect(MAX_PLAYERS).toBe(5)
+  })
+})
+
+describe('EXPANSION_MILESTONES', () => {
+  it('Venus Next includes HOVERLORD', () => {
+    expect(EXPANSION_MILESTONES[Expansion.VENUS_NEXT]).toContain(Milestone.HOVERLORD)
+  })
+
+  it('other expansions have no milestones defined', () => {
+    expect(EXPANSION_MILESTONES[Expansion.PRELUDE]).toBeUndefined()
+    expect(EXPANSION_MILESTONES[Expansion.COLONIES]).toBeUndefined()
+    expect(EXPANSION_MILESTONES[Expansion.TURMOIL]).toBeUndefined()
+  })
+})
+
+describe('EXPANSION_AWARDS', () => {
+  it('Venus Next includes VENUPHILE', () => {
+    expect(EXPANSION_AWARDS[Expansion.VENUS_NEXT]).toContain(Award.VENUPHILE)
+  })
+
+  it('other expansions have no awards defined', () => {
+    expect(EXPANSION_AWARDS[Expansion.PRELUDE]).toBeUndefined()
+    expect(EXPANSION_AWARDS[Expansion.COLONIES]).toBeUndefined()
+    expect(EXPANSION_AWARDS[Expansion.TURMOIL]).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Agrega `EXPANSION_MILESTONES` y `EXPANSION_AWARDS` como tablas de lookup en `gameRules.ts`
- `StepMilestones.tsx` ahora muestra **HOVERLORD** cuando Venus Next está en las expansiones seleccionadas
- `StepAwards.tsx` ahora muestra **VENUPHILE** cuando Venus Next está en las expansiones seleccionadas
- Las opciones desaparecen si Venus Next no está activo (la validación autoritativa sigue siendo el backend)
- 8 tests nuevos agregados — todos 243 tests del frontend pasan en verde

## Test plan

- [x] Crear partida con expansión Venus Next → verificar que HOVERLORD aparece en hitos y VENUPHILE en recompensas
- [x] Crear partida sin Venus Next → verificar que HOVERLORD y VENUPHILE NO aparecen
- [x] `cd frontend && npx vitest run` — todos los tests en verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)